### PR TITLE
Enable single editable merge request comment

### DIFF
--- a/migrations/1744549000000_add-comment-id.js
+++ b/migrations/1744549000000_add-comment-id.js
@@ -1,0 +1,14 @@
+/**
+ * @type {import('node-pg-migrate').MigrationBuilder}
+ */
+exports.shorthands = undefined
+
+exports.up = (pgm) => {
+  pgm.addColumn('merge_requests', {
+    comment_id: { type: 'text' }
+  })
+}
+
+exports.down = (pgm) => {
+  pgm.dropColumn('merge_requests', 'comment_id')
+}

--- a/src/core/StackManager.ts
+++ b/src/core/StackManager.ts
@@ -25,6 +25,7 @@ export class StackManager {
     const commenter = CommentService.getCommenter(payload.provider)
     try {
       logger.info(`[stack] Starting the deployment of the stack for MR #${mrId}`)
+      await db.updateMergeRequest(payload, payload.status)
       await commenter.postStatusComment(payload, 'in_progress')
       // Nettoyage et préparation dossier temporaire
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -43,6 +43,16 @@ export default {
     }
     return map
   },
+  getMergeRequestCommentId: async (projectId: string, mrId: string) => {
+    const result = await pool.query('SELECT comment_id FROM merge_requests WHERE project_id = $1 AND mr_id = $2', [projectId, mrId])
+    if (result.rows.length > 0) {
+      return result.rows[0].comment_id as string | null
+    }
+    return null
+  },
+  setMergeRequestCommentId: async (projectId: string, mrId: string, commentId: string) => {
+    await pool.query('UPDATE merge_requests SET comment_id = $3 WHERE project_id = $1 AND mr_id = $2', [projectId, mrId, commentId])
+  },
   updateMergeRequest: async (payload: MergeRequestPayload, state: string) => {
     await pool.query(
       `

--- a/tests/db/db.test.ts
+++ b/tests/db/db.test.ts
@@ -138,4 +138,18 @@ describe('db/index.ts', () => {
 
     expect(mockPoolInstance.query).toHaveBeenCalledWith(`DELETE FROM exposed_ports WHERE project_id = $1 AND mr_id = $2`, [projectId, mrId])
   })
+
+  it("getMergeRequestCommentId retourne l'id du commentaire", async () => {
+    const mockPoolInstance = (Pool as unknown as jest.Mock).mock.results[0].value
+    mockPoolInstance.query.mockResolvedValueOnce({ rows: [{ comment_id: '10' }] })
+    const id = await db.getMergeRequestCommentId('1', '2')
+    expect(mockPoolInstance.query).toHaveBeenCalledWith('SELECT comment_id FROM merge_requests WHERE project_id = $1 AND mr_id = $2', ['1', '2'])
+    expect(id).toBe('10')
+  })
+
+  it('setMergeRequestCommentId met à jour le commentaire', async () => {
+    const mockPoolInstance = (Pool as unknown as jest.Mock).mock.results[0].value
+    await db.setMergeRequestCommentId('1', '2', '3')
+    expect(mockPoolInstance.query).toHaveBeenCalledWith('UPDATE merge_requests SET comment_id = $3 WHERE project_id = $1 AND mr_id = $2', ['1', '2', '3'])
+  })
 })


### PR DESCRIPTION
## Summary
- store MR comment id in database
- update GitHub/GitLab commenters to edit the existing comment instead of deleting
- record updateMergeRequest earlier when deploying
- tests for new behaviour and DB helpers