### PR TITLE
Remove bun installation from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app
 COPY . /app/
 
 # Installer uniquement les dépendances de production
-RUN npm install --global pm2 && npm install --global bun && cd /app && npm ci && npm run build && npm cache clean --force
+RUN npm install --global pm2 && cd /app && npm ci && npm run build && npm cache clean --force
 
 # Rendre le script d'entrée exécutable
 RUN chmod +x /app/docker/entrypoint.sh


### PR DESCRIPTION
## Summary
- remove the global `bun` installation from the Dockerfile

## Testing
- `npm test`
- ⚠️ `docker build` (fails: Cannot connect to the Docker daemon)

------
https://chatgpt.com/codex/tasks/task_e_6840ce8b22c48323ad15351aa3539a37