### PR TITLE
Add health check worker

### DIFF
--- a/src/core/StackService.ts
+++ b/src/core/StackService.ts
@@ -27,4 +27,8 @@ export class StackService {
   static async getAll(): Promise<StackInfo[]> {
     return await db.getAllStacks()
   }
+
+  static async updateStatus(projectId: string, mrId: string, status: StackStatus): Promise<void> {
+    await db.updateStackStatus(projectId, mrId, status)
+  }
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -88,6 +88,12 @@ export default {
       [projectId, mrId, projectName, mergeRequestName, JSON.stringify(ports), provider, status, JSON.stringify(links)]
     )
   },
+  updateStackStatus: async (projectId: string, mrId: string, status: string) => {
+    await pool.query(
+      `UPDATE stacks SET status = $3, updated_at = now() WHERE project_id = $1 AND mr_id = $2`,
+      [projectId, mrId, status]
+    )
+  },
   removeStack: async (projectId: string, mrId: string) => {
     await pool.query(`DELETE FROM stacks WHERE project_id = $1 AND mr_id = $2`, [projectId, mrId])
   },

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -89,10 +89,7 @@ export default {
     )
   },
   updateStackStatus: async (projectId: string, mrId: string, status: string) => {
-    await pool.query(
-      `UPDATE stacks SET status = $3, updated_at = now() WHERE project_id = $1 AND mr_id = $2`,
-      [projectId, mrId, status]
-    )
+    await pool.query(`UPDATE stacks SET status = $3, updated_at = now() WHERE project_id = $1 AND mr_id = $2`, [projectId, mrId, status])
   },
   removeStack: async (projectId: string, mrId: string) => {
     await pool.query(`DELETE FROM stacks WHERE project_id = $1 AND mr_id = $2`, [projectId, mrId])

--- a/src/health/HealthChecker.ts
+++ b/src/health/HealthChecker.ts
@@ -6,13 +6,7 @@ export class HealthChecker {
   static async checkStack(stack: StackInfo): Promise<StackStatus> {
     const projectName = `${stack.projectId}-mr-${stack.mr_id}`
     try {
-      const { stdout } = await execa('docker', [
-        'ps',
-        '--filter',
-        `label=com.docker.compose.project=${projectName}`,
-        '--format',
-        '{{.State}}'
-      ])
+      const { stdout } = await execa('docker', ['ps', '--filter', `label=com.docker.compose.project=${projectName}`, '--format', '{{.State}}'])
       if (!stdout) {
         return 'error'
       }

--- a/src/health/HealthChecker.ts
+++ b/src/health/HealthChecker.ts
@@ -1,0 +1,44 @@
+import execa from '../docker/execaWrapper'
+import { StackInfo, StackService, StackStatus } from '../core/StackService'
+import logger from '../utils/logger'
+
+export class HealthChecker {
+  static async checkStack(stack: StackInfo): Promise<StackStatus> {
+    const projectName = `${stack.projectId}-mr-${stack.mr_id}`
+    try {
+      const { stdout } = await execa('docker', [
+        'ps',
+        '--filter',
+        `label=com.docker.compose.project=${projectName}`,
+        '--format',
+        '{{.State}}'
+      ])
+      if (!stdout) {
+        return 'error'
+      }
+      const states = stdout.split('\n').filter(Boolean)
+      return states.every((s) => s === 'running') ? 'running' : 'error'
+    } catch (err) {
+      logger.error('[health] Error checking stack', err)
+      return 'error'
+    }
+  }
+
+  static async checkAllStacks(): Promise<void> {
+    const stacks = await StackService.getAll()
+    for (const stack of stacks) {
+      const status = await this.checkStack(stack)
+      if (status !== stack.status) {
+        await StackService.updateStatus(stack.projectId, stack.mr_id, status)
+      }
+    }
+  }
+}
+
+export function startHealthChecker(intervalMs = 30000) {
+  setInterval(() => {
+    HealthChecker.checkAllStacks().catch((err) => {
+      logger.error('[health] Error during health check loop', err)
+    })
+  }, intervalMs)
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import logger from './utils/logger'
 import updateRoute from './api/update'
 import stacksApiRoute from './api/stacksApi'
 import stacksPageRoute from './pages/stacksPage'
+import { startHealthChecker } from './health/HealthChecker'
 
 logger.info('[server] Server is starting...')
 
@@ -24,3 +25,5 @@ const PORT = process.env.PORT ?? 3000
 app.listen(PORT, () => {
   logger.info(`[server] Server running on port ${PORT}`)
 })
+
+startHealthChecker()

--- a/tests/core/StackService.test.ts
+++ b/tests/core/StackService.test.ts
@@ -39,4 +39,9 @@ describe('StackService', () => {
     expect(stacks).toEqual([mockStackInfo])
     expect(mockDb.getAllStacks).toHaveBeenCalled()
   })
+
+  it('should update stack status', async () => {
+    await StackService.updateStatus('1', '2', 'error')
+    expect(mockDb.updateStackStatus).toHaveBeenCalledWith('1', '2', 'error')
+  })
 })

--- a/tests/db/db.test.ts
+++ b/tests/db/db.test.ts
@@ -152,4 +152,13 @@ describe('db/index.ts', () => {
     await db.setMergeRequestCommentId('1', '2', '3')
     expect(mockPoolInstance.query).toHaveBeenCalledWith('UPDATE merge_requests SET comment_id = $3 WHERE project_id = $1 AND mr_id = $2', ['1', '2', '3'])
   })
+
+  it('updateStackStatus met à jour le statut', async () => {
+    const mockPoolInstance = (Pool as unknown as jest.Mock).mock.results[0].value
+    await db.updateStackStatus('1', '2', 'running')
+    expect(mockPoolInstance.query).toHaveBeenCalledWith(
+      'UPDATE stacks SET status = $3, updated_at = now() WHERE project_id = $1 AND mr_id = $2',
+      ['1', '2', 'running']
+    )
+  })
 })

--- a/tests/db/db.test.ts
+++ b/tests/db/db.test.ts
@@ -156,9 +156,10 @@ describe('db/index.ts', () => {
   it('updateStackStatus met à jour le statut', async () => {
     const mockPoolInstance = (Pool as unknown as jest.Mock).mock.results[0].value
     await db.updateStackStatus('1', '2', 'running')
-    expect(mockPoolInstance.query).toHaveBeenCalledWith(
-      'UPDATE stacks SET status = $3, updated_at = now() WHERE project_id = $1 AND mr_id = $2',
-      ['1', '2', 'running']
-    )
+    expect(mockPoolInstance.query).toHaveBeenCalledWith('UPDATE stacks SET status = $3, updated_at = now() WHERE project_id = $1 AND mr_id = $2', [
+      '1',
+      '2',
+      'running'
+    ])
   })
 })

--- a/tests/health/HealthChecker.test.ts
+++ b/tests/health/HealthChecker.test.ts
@@ -1,0 +1,69 @@
+jest.mock('../../src/docker/execaWrapper')
+import execa from '../../src/docker/execaWrapper'
+import { HealthChecker } from '../../src/health/HealthChecker'
+import { StackService, StackInfo } from '../../src/core/StackService'
+
+jest.mock('../../src/core/StackService')
+
+const mockedExeca = execa as unknown as jest.Mock
+const mockedStackService = StackService as jest.Mocked<typeof StackService>
+
+describe('HealthChecker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('checkStack', () => {
+    const stack: StackInfo = {
+      projectId: '1',
+      mr_id: '2',
+      projectName: 'p',
+      mergeRequestName: 'mr',
+      ports: {},
+      provider: 'github',
+      status: 'running',
+      links: {}
+    }
+
+    it('returns running when all containers are running', async () => {
+      mockedExeca.mockResolvedValueOnce({ stdout: 'running\nrunning' })
+      const status = await HealthChecker.checkStack(stack)
+      expect(status).toBe('running')
+      expect(mockedExeca).toHaveBeenCalled()
+    })
+
+    it('returns error when no output', async () => {
+      mockedExeca.mockResolvedValueOnce({ stdout: '' })
+      const status = await HealthChecker.checkStack(stack)
+      expect(status).toBe('error')
+    })
+
+    it('returns error when any container not running', async () => {
+      mockedExeca.mockResolvedValueOnce({ stdout: 'running\nexited' })
+      const status = await HealthChecker.checkStack(stack)
+      expect(status).toBe('error')
+    })
+  })
+
+  describe('checkAllStacks', () => {
+    it('updates status when changed', async () => {
+      const stacks: StackInfo[] = [
+        { projectId: '1', mr_id: '2', projectName: '', mergeRequestName: '', ports: {}, provider: 'github', status: 'running', links: {} }
+      ]
+      mockedStackService.getAll.mockResolvedValueOnce(stacks as any)
+      mockedExeca.mockResolvedValueOnce({ stdout: '' })
+      await HealthChecker.checkAllStacks()
+      expect(mockedStackService.updateStatus).toHaveBeenCalledWith('1', '2', 'error')
+    })
+
+    it('does not update when status unchanged', async () => {
+      const stacks: StackInfo[] = [
+        { projectId: '1', mr_id: '2', projectName: '', mergeRequestName: '', ports: {}, provider: 'github', status: 'running', links: {} }
+      ]
+      mockedStackService.getAll.mockResolvedValueOnce(stacks as any)
+      mockedExeca.mockResolvedValueOnce({ stdout: 'running' })
+      await HealthChecker.checkAllStacks()
+      expect(mockedStackService.updateStatus).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/health/HealthChecker.test.ts
+++ b/tests/health/HealthChecker.test.ts
@@ -50,7 +50,7 @@ describe('HealthChecker', () => {
       const stacks: StackInfo[] = [
         { projectId: '1', mr_id: '2', projectName: '', mergeRequestName: '', ports: {}, provider: 'github', status: 'running', links: {} }
       ]
-      mockedStackService.getAll.mockResolvedValueOnce(stacks as any)
+      mockedStackService.getAll.mockResolvedValueOnce(stacks)
       mockedExeca.mockResolvedValueOnce({ stdout: '' })
       await HealthChecker.checkAllStacks()
       expect(mockedStackService.updateStatus).toHaveBeenCalledWith('1', '2', 'error')
@@ -60,7 +60,7 @@ describe('HealthChecker', () => {
       const stacks: StackInfo[] = [
         { projectId: '1', mr_id: '2', projectName: '', mergeRequestName: '', ports: {}, provider: 'github', status: 'running', links: {} }
       ]
-      mockedStackService.getAll.mockResolvedValueOnce(stacks as any)
+      mockedStackService.getAll.mockResolvedValueOnce(stacks)
       mockedExeca.mockResolvedValueOnce({ stdout: 'running' })
       await HealthChecker.checkAllStacks()
       expect(mockedStackService.updateStatus).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary
- monitor stacks with HealthChecker worker
- update stack status in db when health changes
- display status on `/stacks`
- test HealthChecker and database update

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840ce7abe6483239249b69df0a794c7