### PR TITLE
Improve HealthChecker branch coverage

### DIFF
--- a/tests/comments/GitLabCommenter.test.ts
+++ b/tests/comments/GitLabCommenter.test.ts
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch'
+import fetch, { type Response } from 'node-fetch'
 import logger from '../../src/utils/logger'
 import { MergeRequestPayload } from '../../src/types/MergeRequestPayload'
 import { GitLabCommenter } from '../../src/comments/GitLabCommenter'
@@ -119,7 +119,7 @@ describe('GitLabCommenter', () => {
     })
 
     it('returns empty array and warns when json method is missing', async () => {
-      mockFetch.mockResolvedValueOnce({ status: 200 } as any)
+      mockFetch.mockResolvedValueOnce({ status: 200 } as unknown as Response)
       const comments = await (commenter as GitLabCommenter).getComments('https://gitlab.example.com', '123', '456')
       expect(comments).toEqual([])
       expect(logger.warn).toHaveBeenCalledWith('[gitlab-comment] Unexpected response format, unable to parse comments')

--- a/tests/core/StackManager.test.ts
+++ b/tests/core/StackManager.test.ts
@@ -125,6 +125,24 @@ describe('StackManager.deploy', () => {
     )
   })
 
+  it("utilise simpleGit avec l'option sslVerify=false quand IGNORE_SSL_ERRORS est a true", async () => {
+    delete process.env.REPOSITORY_GITHUB_TOKEN
+    process.env.IGNORE_SSL_ERRORS = 'true'
+    const fakeGit = { clone: jest.fn().mockResolvedValue(undefined) }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockGit.mockReturnValue(fakeGit as any)
+    mockFs.stat.mockResolvedValue({} as Stats)
+    mockFs.readFile.mockResolvedValueOnce('yaml')
+    mockYaml.parse.mockReturnValue({})
+    mockTemplateEngine.renderToFile.mockResolvedValue()
+    mockDocker.up.mockResolvedValue()
+
+    await stackManager.deploy(payload, projectKey)
+
+    expect(mockGit).toHaveBeenCalledWith({ config: ['http.sslVerify=false'] })
+    process.env.IGNORE_SSL_ERRORS = ''
+  })
+
   it('log et relance une erreur si une étape échoue (ex: substitution template)', async () => {
     const stackManager = new StackManager()
     delete process.env.REPOSITORY_GITHUB_TOKEN

--- a/tests/docker/DockerService.test.ts
+++ b/tests/docker/DockerService.test.ts
@@ -1,5 +1,5 @@
 jest.mock('execa') // <-- utilise __mocks__/execa.ts
-import { execa } from 'execa'
+import { execa, type ResultPromise } from 'execa'
 import { DockerService } from '../../src/docker/DockerService'
 import * as ioUtils from '../../src/utils/ioUtils'
 
@@ -60,8 +60,8 @@ describe('DockerService', () => {
         resolve(undefined)
       })
     })
-    Object.assign(promise, { stdout, stderr })
-    mockedExeca.mockReturnValueOnce(promise as any)
+    const childProcess = Object.assign(promise, { stdout, stderr }) as unknown as ResultPromise
+    mockedExeca.mockReturnValueOnce(childProcess)
     const logger = await import('../../src/utils/logger')
     jest.spyOn(logger.default, 'info').mockImplementation(jest.fn())
 
@@ -83,8 +83,8 @@ describe('DockerService', () => {
         resolve(undefined)
       })
     })
-    Object.assign(promise, { stdout, stderr })
-    mockedExeca.mockReturnValueOnce(promise as any)
+    const childProcess = Object.assign(promise, { stdout, stderr }) as unknown as ResultPromise
+    mockedExeca.mockReturnValueOnce(childProcess)
     const logger = await import('../../src/utils/logger')
     jest.spyOn(logger.default, 'info').mockImplementation(jest.fn())
 

--- a/tests/health/HealthChecker.test.ts
+++ b/tests/health/HealthChecker.test.ts
@@ -88,7 +88,7 @@ describe('HealthChecker', () => {
       jest.useRealTimers()
     })
 
-    it('startHealthChecker utilise la valeur par defaut de l\'intervalle', async () => {
+    it("startHealthChecker utilise la valeur par defaut de l'intervalle", async () => {
       jest.useFakeTimers()
       jest.spyOn(HealthChecker, 'checkAllStacks').mockResolvedValueOnce()
       const { startHealthChecker } = await import('../../src/health/HealthChecker')

--- a/tests/health/HealthChecker.test.ts
+++ b/tests/health/HealthChecker.test.ts
@@ -87,5 +87,15 @@ describe('HealthChecker', () => {
       expect(logger.default.error).toHaveBeenCalled()
       jest.useRealTimers()
     })
+
+    it('startHealthChecker utilise la valeur par defaut de l\'intervalle', async () => {
+      jest.useFakeTimers()
+      jest.spyOn(HealthChecker, 'checkAllStacks').mockResolvedValueOnce()
+      const { startHealthChecker } = await import('../../src/health/HealthChecker')
+      startHealthChecker()
+      jest.advanceTimersByTime(30000)
+      expect(HealthChecker.checkAllStacks).toHaveBeenCalled()
+      jest.useRealTimers()
+    })
   })
 })


### PR DESCRIPTION
## Summary
- test HealthChecker default interval to exercise remaining branch

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_6840db8a928483239346a068a4c3050e