### PR TITLE
Add env and template variables docs

### DIFF
--- a/documentation/docs/configuration/environment-variables.md
+++ b/documentation/docs/configuration/environment-variables.md
@@ -1,0 +1,24 @@
+---
+sidebar_position: 6
+---
+
+# Environment Variables
+
+Instantiate is configured through several environment variables. These values
+can be defined in a `.env` file or directly in your deployment files. The
+`.env.example` file in the project root provides a starting point.
+
+## List of variables
+
+- `HOST_DOMAIN` - domain used to build service URLs. Defaults to `localhost`.
+- `HOST_SCHEME` - scheme for service URLs (`http` or `https`). Defaults to `http`.
+- `PORT_MIN` - lowest port number available for exposed services. Defaults to `10000`.
+- `PORT_MAX` - highest port number available for exposed services. Defaults to `11000`.
+- `REPOSITORY_GITLAB_USERNAME` and `REPOSITORY_GITLAB_TOKEN` - credentials for GitLab access and comments.
+- `REPOSITORY_GITHUB_USERNAME` and `REPOSITORY_GITHUB_TOKEN` - credentials for GitHub access and comments.
+- `DATABASE_URL` - PostgreSQL connection string used by the application.
+- `MQTT_BROKER_URL` - URL of the MQTT broker for asynchronous workers.
+- `LOG_LEVEL` - logging level for the server (e.g. `info`, `debug`). Default is `info`.
+- `IGNORE_SSL_ERRORS` - set to `true` to disable SSL verification when cloning repositories or contacting GitLab.
+- `NODE_ENV` - set to `development` for local testing. It alters clone URLs so containers can reach the host machine.
+- `PORT` - HTTP port for the web server. Defaults to `3000`.

--- a/documentation/docs/configuration/template-variables.md
+++ b/documentation/docs/configuration/template-variables.md
@@ -1,0 +1,24 @@
+---
+sidebar_position: 7
+---
+
+# Template Variables
+
+Instantiate renders the file `.instantiate/docker-compose.yml` using Mustache. The following variables are available when the template is processed:
+
+- `PROJECT_KEY` - unique identifier for the repository defined in the webhook URL.
+- `MR_ID` - identifier of the merge request being deployed.
+- `HOST_DOMAIN` - value from the `HOST_DOMAIN` environment variable.
+- `HOST_SCHEME` - value from the `HOST_SCHEME` environment variable.
+- `HOST_DNS` - combination of `HOST_SCHEME` and `HOST_DOMAIN`.
+- Port variables defined in `.instantiate/config.yml` under `expose_ports` (for example `WEB_PORT`, `API_PORT`, ...). Each variable receives a dynamic port allocated for the stack.
+
+Example usage:
+
+```yaml
+services:
+  web:
+    image: nginx
+    ports:
+      - "{{WEB_PORT}}:80"
+```

--- a/documentation/sidebars.ts
+++ b/documentation/sidebars.ts
@@ -30,7 +30,9 @@ const sidebars: SidebarsConfig = {
       items: [
         'configuration/configuration-docker',
         'configuration/configuration-swarm',
-        'configuration/configuration-kubernetes'
+        'configuration/configuration-kubernetes',
+        'configuration/environment-variables',
+        'configuration/template-variables'
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- document environment variables for Instantiate
- document available template variables for Compose templates
- include the docs in the Configuration sidebar

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a98f9b1f0832398faec8e7a473ce7