### PR TITLE
Add stackfile support

### DIFF
--- a/documentation/docs/configuration/configuration-docker.md
+++ b/documentation/docs/configuration/configuration-docker.md
@@ -4,13 +4,14 @@ sidebar_position: 3
 
 # Configuration Docker
 
-Set `orchestrator: compose` in `.instantiate/config.yml` and provide a standard Compose template in `.instantiate/docker-compose.yml`.
+Set `orchestrator: compose` in `.instantiate/config.yml` and provide a standard Compose template. By default Instantiate reads `.instantiate/docker-compose.yml` but you can override this path with the `stackfile` property.
 
 Example:
 
 ```yaml
 # .instantiate/config.yml
 orchestrator: compose
+stackfile: docker-compose.yml
 expose_ports:
   - service: app
     port: 3000

--- a/documentation/docs/configuration/configuration-kubernetes.md
+++ b/documentation/docs/configuration/configuration-kubernetes.md
@@ -5,11 +5,12 @@ next: how-to-contribute
 
 # Configuration Kubernetes
 
-If you use Kubernetes, set `orchestrator: kubernetes` and place your manifests in `.instantiate/docker-compose.yml`.
+If you use Kubernetes, set `orchestrator: kubernetes`. Instantiate looks for the manifest file `.instantiate/all.yml` by default. You can change this path using the `stackfile` option.
 
 ```yaml
 # .instantiate/config.yml
 orchestrator: kubernetes
+stackfile: all.yml
 expose_ports:
   - service: web
     port: 80
@@ -17,7 +18,7 @@ expose_ports:
 ```
 
 ```yaml
-# .instantiate/docker-compose.yml
+# .instantiate/all.yml
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/documentation/docs/configuration/configuration-swarm.md
+++ b/documentation/docs/configuration/configuration-swarm.md
@@ -4,11 +4,12 @@ sidebar_position: 4
 
 # Configuration Swarm
 
-To deploy stacks on Docker Swarm set `orchestrator: swarm` and use a Compose file with Swarm specific options.
+To deploy stacks on Docker Swarm set `orchestrator: swarm` and use a Compose file with Swarm specific options. The stack template defaults to `.instantiate/docker-compose.yml` and can be changed with the `stackfile` option.
 
 ```yaml
 # .instantiate/config.yml
 orchestrator: swarm
+stackfile: docker-compose.yml
 expose_ports:
   - service: web
     port: 80

--- a/documentation/docs/configuration/template-variables.md
+++ b/documentation/docs/configuration/template-variables.md
@@ -4,7 +4,7 @@ sidebar_position: 7
 
 # Template Variables
 
-Instantiate renders the file `.instantiate/docker-compose.yml` using Mustache. The following variables are available when the template is processed:
+Instantiate renders the stack template defined in `.instantiate/config.yml` using Mustache. By default the file is `docker-compose.yml` (or `all.yml` for Kubernetes). The following variables are available when the template is processed:
 
 - `PROJECT_KEY` - unique identifier for the repository defined in the webhook URL.
 - `MR_ID` - identifier of the merge request being deployed.

--- a/tests/core/StackManager.test.ts
+++ b/tests/core/StackManager.test.ts
@@ -265,7 +265,7 @@ describe('StackManager.deploy', () => {
       'missing-compose-project'
     )
 
-    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('Unable to find the docker-compose file'))
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('Unable to find the stack template file'))
     expect(mockDocker.prototype.up).not.toHaveBeenCalled()
     expect(mockDb.addExposedPorts).not.toHaveBeenCalled()
 


### PR DESCRIPTION
## Summary
- support `stackfile` parameter in config
- default Kubernetes template file is `all.yml`
- document how to set custom stack templates

## Testing
- `npm run lint`
- `npm test`
- `yes | npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a9e37a3e48323b50f78ed73083a41