### PR TITLE
Support external repositories

### DIFF
--- a/documentation/docs/configuration/configuration-docker.md
+++ b/documentation/docs/configuration/configuration-docker.md
@@ -12,6 +12,10 @@ Example:
 # .instantiate/config.yml
 orchestrator: compose
 stackfile: docker-compose.yml
+repositories:
+  backend:
+    repo: git@github.com:org/backend.git
+    branch: develop
 expose_ports:
   - service: app
     port: 3000
@@ -25,4 +29,7 @@ services:
     build: .
     ports:
       - "{{APP_PORT}}:3000"
+  backend:
+    build:
+      context: {{BACKEND_PATH}}
 ```

--- a/documentation/docs/configuration/template-variables.md
+++ b/documentation/docs/configuration/template-variables.md
@@ -12,6 +12,7 @@ Instantiate renders the stack template defined in `.instantiate/config.yml` usin
 - `HOST_SCHEME` - value from the `HOST_SCHEME` environment variable.
 - `HOST_DNS` - combination of `HOST_SCHEME` and `HOST_DOMAIN`.
 - Port variables defined in `.instantiate/config.yml` under `expose_ports` (for example `WEB_PORT`, `API_PORT`, ...). Each variable receives a dynamic port allocated for the stack.
+- `*_PATH` - path on disk of repositories defined under `repositories` in `.instantiate/config.yml`. The variable name is the repository key uppercased followed by `_PATH` (e.g. `BACKEND_PATH`).
 
 Example usage:
 

--- a/src/core/StackManager.ts
+++ b/src/core/StackManager.ts
@@ -70,6 +70,16 @@ export class StackManager {
         return null
       }
 
+      const repoPaths: Record<string, string> = {}
+      if (config.repositories) {
+        const repos = config.repositories as Record<string, { repo: string; branch: string }>
+        for (const [name, repoCfg] of Object.entries(repos)) {
+          const repoPath = path.join(tmpPath, name)
+          await git.clone(repoCfg.repo, repoPath, ['--branch', repoCfg.branch])
+          repoPaths[name.toUpperCase() + '_PATH'] = repoPath
+        }
+      }
+
       const adapter = getOrchestratorAdapter(orchestrator)
       const composeOutput = path.join(tmpPath, 'docker-compose.yml')
 
@@ -91,6 +101,7 @@ export class StackManager {
         HOST_DNS: hostDns,
         HOST_DOMAIN: hostDomain,
         HOST_SCHEME: hostScheme,
+        ...repoPaths,
         ...ports // injecte WEB_PORT, API_PORT, etc.
       }
 


### PR DESCRIPTION
## Summary
- add repositories section to docker config docs and show build context usage
- list `*_PATH` template variables in docs
- support cloning additional repositories in `StackManager`
- expose repository paths to templates
- test repository cloning and variable injection

## Testing
- `npm run lint`
- `npm run test`
- `yes | npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684b376d0f3c8323905269df26073b66