### PR TITLE
Refactor config schema for service ports

### DIFF
--- a/documentation/docs/configuration/configuration-docker.md
+++ b/documentation/docs/configuration/configuration-docker.md
@@ -12,15 +12,17 @@ Example:
 # .instantiate/config.yml
 orchestrator: compose
 stackfile: docker-compose.yml
-repositories:
-  backend:
-    repo: git@github.com:org/backend.git
-    branch: develop
-    behavior: match
-expose_ports:
-  - service: app
+
+services:
+  app:
     port: 3000
-    name: APP_PORT
+  backend:
+    repository:
+      repo: git@github.com:org/backend.git
+      branch: develop
+      behavior: match
+    ports:
+      - 8080
 ```
 
 The `behavior` property controls how Instantiate selects the branch to clone:

--- a/documentation/docs/configuration/configuration-kubernetes.md
+++ b/documentation/docs/configuration/configuration-kubernetes.md
@@ -11,10 +11,10 @@ If you use Kubernetes, set `orchestrator: kubernetes`. Instantiate looks for the
 # .instantiate/config.yml
 orchestrator: kubernetes
 stackfile: all.yml
-expose_ports:
-  - service: web
+
+services:
+  web:
     port: 80
-    name: WEB_PORT
 ```
 
 ```yaml

--- a/documentation/docs/configuration/configuration-swarm.md
+++ b/documentation/docs/configuration/configuration-swarm.md
@@ -10,10 +10,10 @@ To deploy stacks on Docker Swarm set `orchestrator: swarm` and use a Compose fil
 # .instantiate/config.yml
 orchestrator: swarm
 stackfile: docker-compose.yml
-expose_ports:
-  - service: web
+
+services:
+  web:
     port: 80
-    name: WEB_PORT
 ```
 
 ```yaml

--- a/documentation/docs/configuration/template-variables.md
+++ b/documentation/docs/configuration/template-variables.md
@@ -11,8 +11,8 @@ Instantiate renders the stack template defined in `.instantiate/config.yml` usin
 - `HOST_DOMAIN` - value from the `HOST_DOMAIN` environment variable.
 - `HOST_SCHEME` - value from the `HOST_SCHEME` environment variable.
 - `HOST_DNS` - combination of `HOST_SCHEME` and `HOST_DOMAIN`.
-- Port variables defined in `.instantiate/config.yml` under `expose_ports` (for example `WEB_PORT`, `API_PORT`, ...). Each variable receives a dynamic port allocated for the stack.
-- `*_PATH` - path on disk of repositories defined under `repositories` in `.instantiate/config.yml`. The variable name is the repository key uppercased followed by `_PATH` (e.g. `BACKEND_PATH`).
+- Port variables defined in `.instantiate/config.yml` under `services`. For each service using `port` or `ports`, Instantiate exposes variables like `APP_PORT` or `APP_PORT_1`, `APP_PORT_2`, etc. Each variable receives a dynamic port allocated for the stack.
+- `*_PATH` - path on disk of repositories defined for services under `services`. The variable name is the service key uppercased followed by `_PATH` (e.g. `BACKEND_PATH`).
 
 Example usage:
 

--- a/tests/core/StackManager.test.ts
+++ b/tests/core/StackManager.test.ts
@@ -72,10 +72,10 @@ describe('StackManager.deploy', () => {
     // Mock lecture du fichier YAML
     mockFs.readFile.mockResolvedValueOnce('fake-yaml-content')
     mockYaml.parse.mockReturnValue({
-      expose_ports: [
-        { service: 'web', name: 'WEB_PORT', port: 3000 },
-        { service: 'api', name: 'API_PORT', port: 8000 }
-      ]
+      services: {
+        web: { port: 3000 },
+        api: { port: 8000 }
+      }
     })
 
     // Mock ports dynamiques
@@ -141,8 +141,8 @@ describe('StackManager.deploy', () => {
 
     mockFs.readFile.mockResolvedValueOnce('yaml')
     mockYaml.parse.mockReturnValue({
-      repositories: {
-        backend: { repo: 'git@github.com:org/backend.git', branch: 'develop' }
+      services: {
+        backend: { repository: { repo: 'git@github.com:org/backend.git', branch: 'develop' } }
       }
     })
 
@@ -169,8 +169,8 @@ describe('StackManager.deploy', () => {
 
     mockFs.readFile.mockResolvedValueOnce('yaml')
     mockYaml.parse.mockReturnValue({
-      repositories: {
-        backend: { repo: 'git@github.com:org/backend.git', branch: 'develop', behavior: 'match' }
+      services: {
+        backend: { repository: { repo: 'git@github.com:org/backend.git', branch: 'develop', behavior: 'match' } }
       }
     })
 
@@ -193,8 +193,8 @@ describe('StackManager.deploy', () => {
 
     mockFs.readFile.mockResolvedValueOnce('yaml')
     mockYaml.parse.mockReturnValue({
-      repositories: {
-        backend: { repo: 'git@github.com:org/backend.git', branch: 'develop', behavior: 'match' }
+      services: {
+        backend: { repository: { repo: 'git@github.com:org/backend.git', branch: 'develop', behavior: 'match' } }
       }
     })
 
@@ -237,7 +237,9 @@ describe('StackManager.deploy', () => {
 
     mockFs.readFile.mockResolvedValueOnce('yaml')
     mockYaml.parse.mockReturnValue({
-      expose_ports: [{ service: 'web', port: 3000, name: 'WEB_PORT' }]
+      services: {
+        web: { port: 3000 }
+      }
     })
 
     mockPorts.allocatePort.mockResolvedValueOnce(10001)


### PR DESCRIPTION
## Summary
- support new `services` structure with automatic port variable names
- update tests for `StackManager`
- document new configuration for Compose, Swarm and Kubernetes
- revise template variables docs

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b441c6ca88323b154d0bc4f040180