### PR TITLE
Update port configuration handling

### DIFF
--- a/documentation/docs/configuration/configuration-docker.md
+++ b/documentation/docs/configuration/configuration-docker.md
@@ -15,14 +15,13 @@ stackfile: docker-compose.yml
 
 services:
   app:
-    port: 3000
+    ports: 1
   backend:
     repository:
       repo: git@github.com:org/backend.git
       branch: develop
       behavior: match
-    ports:
-      - 8080
+    ports: 1
 ```
 
 The `behavior` property controls how Instantiate selects the branch to clone:

--- a/documentation/docs/configuration/configuration-kubernetes.md
+++ b/documentation/docs/configuration/configuration-kubernetes.md
@@ -14,7 +14,7 @@ stackfile: all.yml
 
 services:
   web:
-    port: 80
+    ports: 1
 ```
 
 ```yaml

--- a/documentation/docs/configuration/configuration-swarm.md
+++ b/documentation/docs/configuration/configuration-swarm.md
@@ -13,7 +13,7 @@ stackfile: docker-compose.yml
 
 services:
   web:
-    port: 80
+    ports: 1
 ```
 
 ```yaml

--- a/documentation/docs/configuration/template-variables.md
+++ b/documentation/docs/configuration/template-variables.md
@@ -11,7 +11,7 @@ Instantiate renders the stack template defined in `.instantiate/config.yml` usin
 - `HOST_DOMAIN` - value from the `HOST_DOMAIN` environment variable.
 - `HOST_SCHEME` - value from the `HOST_SCHEME` environment variable.
 - `HOST_DNS` - combination of `HOST_SCHEME` and `HOST_DOMAIN`.
-- Port variables defined in `.instantiate/config.yml` under `services`. For each service using `port` or `ports`, Instantiate exposes variables like `APP_PORT` or `APP_PORT_1`, `APP_PORT_2`, etc. Each variable receives a dynamic port allocated for the stack.
+- Port variables defined in `.instantiate/config.yml` under `services`. For each service defining `ports`, Instantiate exposes variables like `APP_PORT` or `APP_PORT_1`, `APP_PORT_2`, etc. The number provided for `ports` determines how many dynamic ports are reserved.
 - `*_PATH` - path on disk of repositories defined for services under `services`. The variable name is the service key uppercased followed by `_PATH` (e.g. `BACKEND_PATH`).
 
 Example usage:

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "gh-pages": "^6.3.0",
         "jest": "^29.7.0",
         "mock-fs": "^5.5.0",
+        "ncp": "^2.0.0",
         "node-pg-migrate": "^8.0.0",
         "pino-pretty": "^13.0.0",
         "prettier": "^3.5.3",
@@ -6317,6 +6318,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncp": "bin/ncp"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gh-pages": "^6.3.0",
     "jest": "^29.7.0",
     "mock-fs": "^5.5.0",
+    "ncp": "^2.0.0",
     "node-pg-migrate": "^8.0.0",
     "pino-pretty": "^13.0.0",
     "prettier": "^3.5.3",

--- a/src/core/PortAllocator.ts
+++ b/src/core/PortAllocator.ts
@@ -12,7 +12,7 @@ export class PortAllocator {
   private static get portMax(): number {
     return parseInt(process.env.PORT_MAX ?? DEFAULT_PORT_MAX.toString(), 10)
   }
-  static async allocatePort(projectId: string, mrId: string, service: string, name: string, internalPort: number): Promise<number> {
+  static async allocatePort(projectId: string, mrId: string, service: string, name: string): Promise<number> {
     const alreadyAllocatedPort = await db.allreadyAllocatedPort(projectId, mrId, service, name)
     if (alreadyAllocatedPort) {
       logger.info(`[port] Port already allocated : ${alreadyAllocatedPort} for ${service} ${name} (MR:${mrId})`)
@@ -23,7 +23,7 @@ export class PortAllocator {
     const max = PortAllocator.portMax
     for (let port = min; port <= max; port++) {
       if (!usedPorts.has(port)) {
-        await db.addExposedPorts(projectId, mrId, service, name, internalPort, port)
+        await db.addExposedPorts(projectId, mrId, service, name, 0, port)
         logger.info(`[port] Port allocated : ${port} for ${service} ${name} (MR:${mrId})`)
         return port
       }

--- a/src/core/StackManager.ts
+++ b/src/core/StackManager.ts
@@ -103,24 +103,16 @@ export class StackManager {
       const ports: Record<string, number> = {}
       const portsLinks: Record<string, string> = {}
       if (config.services) {
-        const services = config.services as Record<string, { port?: number; ports?: number[] }>
+        const services = config.services as Record<string, { ports?: number }>
         for (const [serviceName, serviceCfg] of Object.entries(services)) {
-          const definedPorts: number[] = []
-          if (typeof serviceCfg.port === 'number') {
-            definedPorts.push(serviceCfg.port)
-          }
-          if (Array.isArray(serviceCfg.ports)) {
-            definedPorts.push(...serviceCfg.ports)
-          }
-          let index = 1
-          for (const internal of definedPorts) {
-            const varName = definedPorts.length > 1 ? `${serviceName.toUpperCase()}_PORT_${index}` : `${serviceName.toUpperCase()}_PORT`
-            const ext = await PortAllocator.allocatePort(projectId, mrId, serviceName, varName, internal)
+          const count = typeof serviceCfg.ports === 'number' ? serviceCfg.ports : 0
+          for (let index = 1; index <= count; index++) {
+            const varName = count > 1 ? `${serviceName.toUpperCase()}_PORT_${index}` : `${serviceName.toUpperCase()}_PORT`
+            const ext = await PortAllocator.allocatePort(projectId, mrId, serviceName, varName)
             ports[varName] = ext
             if (!portsLinks[serviceName]) {
               portsLinks[serviceName] = `${hostDns}:${ext}`
             }
-            index++
           }
         }
       }

--- a/tests/core/PortAllocator.test.ts
+++ b/tests/core/PortAllocator.test.ts
@@ -33,17 +33,17 @@ describe('PortAllocator', () => {
     mockDb.allreadyAllocatedPort.mockResolvedValueOnce(null)
     mockDb.getUsedPorts.mockResolvedValueOnce(new Set([10000, 10001]))
 
-    const port = await PortAllocator.allocatePort('valcriss', 'mr-1', 'web', 'WEB_PORT', 3000)
+    const port = await PortAllocator.allocatePort('valcriss', 'mr-1', 'web', 'WEB_PORT')
 
     expect(port).toEqual(10002)
-    expect(mockDb.addExposedPorts).toHaveBeenCalledWith('valcriss', 'mr-1', 'web', 'WEB_PORT', 3000, 10002)
+    expect(mockDb.addExposedPorts).toHaveBeenCalledWith('valcriss', 'mr-1', 'web', 'WEB_PORT', 0, 10002)
   })
 
   it('ignore les ports déjà utilisés', async () => {
     mockDb.allreadyAllocatedPort.mockResolvedValueOnce(null)
     mockDb.getUsedPorts.mockResolvedValueOnce(new Set([10000, 10001]))
 
-    const port = await PortAllocator.allocatePort('valcriss', 'mr-2', 'api', 'API_PORT', 8000)
+    const port = await PortAllocator.allocatePort('valcriss', 'mr-2', 'api', 'API_PORT')
     expect(port).toBe(10002)
   })
 
@@ -58,7 +58,7 @@ describe('PortAllocator', () => {
     for (let p = min; p <= max; p++) used.push(p)
     mockDb.getUsedPorts.mockResolvedValueOnce(new Set(used))
 
-    await expect(PortAllocator.allocatePort('valcriss', 'mr-3', 'db', 'BD_PORT', 5432)).rejects.toThrow('There is no available port')
+    await expect(PortAllocator.allocatePort('valcriss', 'mr-3', 'db', 'BD_PORT')).rejects.toThrow('There is no available port')
   })
 
   it('supprime tous les ports d’une MR via releasePorts', async () => {
@@ -75,7 +75,7 @@ describe('PortAllocator', () => {
 
   it('retourne le port déjà alloué si allreadyAllocatedPort retourne une valeur', async () => {
     mockDb.allreadyAllocatedPort.mockResolvedValueOnce(10005)
-    const port = await PortAllocator.allocatePort('valcriss', 'mr-4', 'cache', 'CACHE_PORT', 6379)
+    const port = await PortAllocator.allocatePort('valcriss', 'mr-4', 'cache', 'CACHE_PORT')
 
     expect(port).toBe(10005)
     expect(mockDb.allreadyAllocatedPort).toHaveBeenCalledWith('valcriss', 'mr-4', 'cache', 'CACHE_PORT')
@@ -87,9 +87,9 @@ describe('PortAllocator', () => {
     mockDb.allreadyAllocatedPort.mockResolvedValueOnce(null)
     mockDb.getUsedPorts.mockResolvedValueOnce(new Set([20000, 20001]))
 
-    const port = await PortAllocator.allocatePort('valcriss', 'mr-env', 'svc', 'SVC_PORT', 1234)
+    const port = await PortAllocator.allocatePort('valcriss', 'mr-env', 'svc', 'SVC_PORT')
 
     expect(port).toBe(20002)
-    expect(mockDb.addExposedPorts).toHaveBeenCalledWith('valcriss', 'mr-env', 'svc', 'SVC_PORT', 1234, 20002)
+    expect(mockDb.addExposedPorts).toHaveBeenCalledWith('valcriss', 'mr-env', 'svc', 'SVC_PORT', 0, 20002)
   })
 })

--- a/tests/core/StackManager.test.ts
+++ b/tests/core/StackManager.test.ts
@@ -73,8 +73,8 @@ describe('StackManager.deploy', () => {
     mockFs.readFile.mockResolvedValueOnce('fake-yaml-content')
     mockYaml.parse.mockReturnValue({
       services: {
-        web: { port: 3000 },
-        api: { port: 8000 }
+        web: { ports: 1 },
+        api: { ports: 1 }
       }
     })
 
@@ -96,8 +96,8 @@ describe('StackManager.deploy', () => {
     // ✅ Assertions clés
     expect(fakeGit.clone).toHaveBeenCalled()
     expect(mockFs.readFile).toHaveBeenCalled()
-    expect(mockPorts.allocatePort).toHaveBeenCalledWith('valcriss', 'mr-42', 'web', 'WEB_PORT', 3000)
-    expect(mockPorts.allocatePort).toHaveBeenCalledWith('valcriss', 'mr-42', 'api', 'API_PORT', 8000)
+    expect(mockPorts.allocatePort).toHaveBeenCalledWith('valcriss', 'mr-42', 'web', 'WEB_PORT')
+    expect(mockPorts.allocatePort).toHaveBeenCalledWith('valcriss', 'mr-42', 'api', 'API_PORT')
 
     expect(mockTemplateEngine.renderToFile).toHaveBeenCalledWith(
       expect.stringContaining('docker-compose.yml'),
@@ -238,7 +238,7 @@ describe('StackManager.deploy', () => {
     mockFs.readFile.mockResolvedValueOnce('yaml')
     mockYaml.parse.mockReturnValue({
       services: {
-        web: { port: 3000 }
+        web: { ports: 1 }
       }
     })
 


### PR DESCRIPTION
## Summary
- change `ports` to define number of reserved ports
- remove support for `port` key
- update allocator and stack manager accordingly
- update docs and tests
- add `ncp` dev dependency for build step

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b493f3f288323842427cfb0745f0e