### PR TITLE
Add debug logs for API webhook

### DIFF
--- a/src/api/update.ts
+++ b/src/api/update.ts
@@ -8,6 +8,11 @@ import { MergeRequestPayload } from '../types/MergeRequestPayload'
 const router = express.Router()
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 router.post('/update', async (req: any, res: any) => {
+  logger.debug('[api] Incoming webhook', {
+    query: req.query,
+    headers: req.headers
+  })
+
   const projectKey = req.query.key as string
   const headers = req.headers
 
@@ -24,6 +29,8 @@ router.post('/update', async (req: any, res: any) => {
     provider = 'github'
   }
 
+  logger.debug('[api] Determined provider', provider)
+
   if (!provider) {
     logger.warn('[api] Unsupported source control provider')
     return res.status(400).json({ error: 'Unsupported source control provider' })
@@ -32,13 +39,14 @@ router.post('/update', async (req: any, res: any) => {
   try {
     const payload = provider === 'gitlab' ? parseGitlabWebhook(req.body) : parseGithubWebhook(req.body)
 
+    logger.debug('[api] Parsed payload', payload)
     logger.info(`[api] Received ${payload.status} event for MR #${payload.mr_id} from ${provider}`)
 
     enqueueUpdateEvent({ payload, projectKey })
 
     res.status(200).json({ success: true })
   } catch (err: unknown) {
-    logger.error('[api] Error handling webhook', err)
+    logger.error({ err }, '[api] Error handling webhook')
     res.status(500).json({ error: 'Internal error', err: (err as Error).message })
   }
 })
@@ -46,9 +54,10 @@ router.post('/update', async (req: any, res: any) => {
 export function enqueueUpdateEvent(data: { payload: MergeRequestPayload; projectKey: string }) {
   try {
     ensureMQTTClientIsInitialized()
+    logger.debug('[api] Publishing update event', data)
     publishUpdateEvent(data)
   } catch (err) {
-    logger.error('[api] Failed to enqueue update event')
+    logger.error({ err }, '[api] Failed to enqueue update event')
   }
 }
 

--- a/tests/api/updateRoute.test.ts
+++ b/tests/api/updateRoute.test.ts
@@ -137,6 +137,6 @@ describe('POST /api/update', () => {
 
     enqueueUpdateEvent({ payload: fakePayload, projectKey: 'key' })
 
-    expect(logger.error).toHaveBeenCalledWith('[api] Failed to enqueue update event')
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ err: expect.any(Error) }), '[api] Failed to enqueue update event')
   })
 })


### PR DESCRIPTION
## Summary
- emit debug logs in the update route so we can better diagnose webhook failures
- adapt tests to new logging output

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851c6aa2ba88323886a106fba8a80d4