### PR TITLE
Fix duplicate credentials in clone URLs

### DIFF
--- a/src/core/StackManager.ts
+++ b/src/core/StackManager.ts
@@ -12,6 +12,7 @@ import { PortAllocator } from './PortAllocator'
 import { CommentService } from '../comments/CommentService'
 import { StackService } from './StackService'
 import { createDirectory, removeDirectory } from '../utils/ioUtils'
+import { injectCredentialsIfMissing } from '../utils/gitUrl'
 
 export class StackManager {
   async deploy(payload: MergeRequestPayload, projectKey: string) {
@@ -19,15 +20,11 @@ export class StackManager {
     const mrId = payload.mr_id
     const tmpPath = path.join(os.tmpdir(), 'instantiate', projectId.toString(), mrId.toString())
     let cloneUrl = `${payload.repo}`
-    if (payload.provider === 'gitlab' && process.env.REPOSITORY_GITLAB_USERNAME && process.env.REPOSITORY_GITLAB_TOKEN) {
-      const creds = `${process.env.REPOSITORY_GITLAB_USERNAME}:${process.env.REPOSITORY_GITLAB_TOKEN}`
-      cloneUrl = cloneUrl.replace('https://', `https://${creds}@`)
-      cloneUrl = cloneUrl.replace('http://', `http://${creds}@`)
+    if (payload.provider === 'gitlab') {
+      cloneUrl = injectCredentialsIfMissing(cloneUrl, process.env.REPOSITORY_GITLAB_USERNAME, process.env.REPOSITORY_GITLAB_TOKEN)
     }
-    if (payload.provider === 'github' && process.env.REPOSITORY_GITHUB_USERNAME && process.env.REPOSITORY_GITHUB_TOKEN) {
-      const creds = `${process.env.REPOSITORY_GITHUB_USERNAME}:${process.env.REPOSITORY_GITHUB_TOKEN}`
-      cloneUrl = cloneUrl.replace('https://', `https://${creds}@`)
-      cloneUrl = cloneUrl.replace('http://', `http://${creds}@`)
+    if (payload.provider === 'github') {
+      cloneUrl = injectCredentialsIfMissing(cloneUrl, process.env.REPOSITORY_GITHUB_USERNAME, process.env.REPOSITORY_GITHUB_TOKEN)
     }
     const hostDomain = process.env.HOST_DOMAIN ?? 'localhost'
     const hostScheme = process.env.HOST_SCHEME ?? 'http'

--- a/src/utils/gitUrl.ts
+++ b/src/utils/gitUrl.ts
@@ -1,0 +1,17 @@
+export function injectCredentialsIfMissing(url: string, username: string | undefined, token: string | undefined): string {
+  if (!username || !token) {
+    return url
+  }
+  const hasCreds = /^https?:\/\/[^@]+@/.test(url)
+  if (hasCreds) {
+    return url
+  }
+  const creds = `${username}:${token}`
+  if (url.startsWith('https://')) {
+    return url.replace('https://', `https://${creds}@`)
+  }
+  if (url.startsWith('http://')) {
+    return url.replace('http://', `http://${creds}@`)
+  }
+  return url
+}

--- a/tests/utils/gitUrl.test.ts
+++ b/tests/utils/gitUrl.test.ts
@@ -1,0 +1,30 @@
+import { injectCredentialsIfMissing } from '../../src/utils/gitUrl'
+
+describe('injectCredentialsIfMissing', () => {
+  it('adds credentials when missing', () => {
+    const result = injectCredentialsIfMissing('https://github.com/test/repo.git', 'user', 'token')
+    expect(result).toBe('https://user:token@github.com/test/repo.git')
+  })
+
+  it('does not add credentials if already present', () => {
+    const result = injectCredentialsIfMissing('https://user:token@github.com/test/repo.git', 'user', 'token')
+    expect(result).toBe('https://user:token@github.com/test/repo.git')
+  })
+
+  it('returns same url when username or token is missing', () => {
+    const result1 = injectCredentialsIfMissing('https://github.com/test/repo.git', undefined, 'token')
+    expect(result1).toBe('https://github.com/test/repo.git')
+    const result2 = injectCredentialsIfMissing('https://github.com/test/repo.git', 'user', undefined)
+    expect(result2).toBe('https://github.com/test/repo.git')
+  })
+
+  it('handles http protocol', () => {
+    const result = injectCredentialsIfMissing('http://github.com/test/repo.git', 'user', 'token')
+    expect(result).toBe('http://user:token@github.com/test/repo.git')
+  })
+
+  it('returns url unchanged for unsupported scheme', () => {
+    const result = injectCredentialsIfMissing('git@github.com:test/repo.git', 'user', 'token')
+    expect(result).toBe('git@github.com:test/repo.git')
+  })
+})


### PR DESCRIPTION
## Summary
- avoid injecting credentials twice when cloning repositories
- update Github/Gitlab providers to use helper
- test for clone URL credential injection
- add gitUrl utility with tests for full coverage

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851d1555c5c8323b7e6543ddc95206f