### PR TITLE
Fix compose YAML schema validation

### DIFF
--- a/src/utils/stackValidator.ts
+++ b/src/utils/stackValidator.ts
@@ -24,7 +24,8 @@ export async function validateStackFile(filePath: string, orchestrator: Orchestr
   if (orchestrator === 'compose' || orchestrator === 'swarm') {
     const res = await fetch(COMPOSE_SCHEMA_URL)
     const composeSchema = (await res.json()) as AnySchema
-    const ajv = new Ajv()
+    const ajv = new Ajv({ meta: false })
+    ajv.addMetaSchema(require('ajv/dist/refs/json-schema-draft-07.json'))
     const validate = ajv.compile(composeSchema)
     if (!validate(parsed)) {
       throw new Error(`[validator] ${filePath} does not match compose schema`)


### PR DESCRIPTION
## Summary
- add draft-07 metaschema to Ajv when validating compose files

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851e552effc83239a8b887f9e3b6c58