### PR TITLE
Update sanitizeName for hyphen and slash handling

### DIFF
--- a/src/utils/nameUtils.ts
+++ b/src/utils/nameUtils.ts
@@ -2,7 +2,8 @@ export function sanitizeName(name: string): string {
   return name
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-zA-Z0-9]+/g, '')
+    .replace(/[\\/]/g, '-')
+    .replace(/[^a-zA-Z0-9-]+/g, '')
     .toLowerCase()
 }
 

--- a/tests/utils/nameUtils.test.ts
+++ b/tests/utils/nameUtils.test.ts
@@ -2,9 +2,14 @@ import { sanitizeName, buildStackName } from '../../src/utils/nameUtils'
 
 describe('nameUtils', () => {
   describe('sanitizeName', () => {
-    it('removes accents and special characters', () => {
-      const result = sanitizeName('Pr\xE9s-\xE9ntation !')
-      expect(result).toBe('presentation')
+    it('removes accents, keeps dashes and replaces slashes', () => {
+      const result = sanitizeName('Pr\xE9s-\xE9nt/ation !')
+      expect(result).toBe('pres-ent-ation')
+    })
+
+    it('replaces backslashes with dashes', () => {
+      const result = sanitizeName('folder\\file')
+      expect(result).toBe('folder-file')
     })
   })
 


### PR DESCRIPTION
## Summary
- keep existing hyphens and turn `\`/`/` into dashes in `sanitizeName`
- add tests for the new behaviour

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852ed5046bc8323b2313649c26e7063