### PR TITLE
Add prebuild support in service config

### DIFF
--- a/documentation/docs/configuration/orchestrators/configuration-docker.md
+++ b/documentation/docs/configuration/orchestrators/configuration-docker.md
@@ -15,6 +15,11 @@ stackfile: docker-compose.yml
 
 services:
   app:
+    prebuild:
+      image: node:23
+      commands:
+        - npm install
+        - npm run build
     ports: 1
   backend:
     repository:
@@ -28,6 +33,8 @@ The `behavior` property controls how Instantiate selects the branch to clone:
 
 - `fixed` (default) always clones the branch specified in `branch` (or the repository's default branch if `branch` is omitted).
 - `match` tries to clone a branch with the same name as the merge request. If that branch does not exist, the value of `branch` or the default branch is used instead.
+
+Use the optional `prebuild` object to run commands before Docker builds the image. Commands execute inside a temporary container defined by `image`. The service code is mounted in `/app` by default and the directory can be changed with `mountpath`.
 
 ```yaml
 # .instantiate/docker-compose.yml

--- a/documentation/docs/configuration/orchestrators/configuration-kubernetes.md
+++ b/documentation/docs/configuration/orchestrators/configuration-kubernetes.md
@@ -14,8 +14,15 @@ stackfile: all.yml
 
 services:
   web:
+    prebuild:
+      image: node:23
+      commands:
+        - npm install
+        - npm run build
     ports: 1
 ```
+
+Use the optional `prebuild` object to run commands before Docker builds the image. Commands execute inside a temporary container defined by `image`. The code is mounted in `/app` unless overridden by `mountpath`.
 
 ```yaml
 # .instantiate/all.yml

--- a/documentation/docs/configuration/orchestrators/configuration-swarm.md
+++ b/documentation/docs/configuration/orchestrators/configuration-swarm.md
@@ -13,8 +13,15 @@ stackfile: docker-compose.yml
 
 services:
   web:
+    prebuild:
+      image: node:23
+      commands:
+        - npm install
+        - npm run build
     ports: 1
 ```
+
+Use the optional `prebuild` object to run commands before Docker builds the image. Commands execute inside a temporary container defined by `image`. The service code is mounted in `/app` by default and can be changed using `mountpath`.
 
 ```yaml
 # .instantiate/docker-compose.yml


### PR DESCRIPTION
## Summary
- allow defining `prebuild` step for services
- document the new `prebuild` section in orchestrator docs
- execute `prebuild` commands before building services
- test prebuild logic

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68540e94a9ec83238dbd5bc42c2cdc8a