### PR TITLE
Mount tmp for docker prebuilds

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,6 +13,7 @@ services:
       - "3000:3000"
     volumes:
       - //var/run/docker.sock:/var/run/docker.sock
+      - /tmp:/tmp
     environment:
       - NODE_ENV=development
       # - LOG_LEVEL=info      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - "3000:3000"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp:/tmp
     environment:
       - NODE_ENV=production
       # - LOG_LEVEL=info

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -32,6 +32,14 @@ Instantiate is distributed as a Docker Compose stack. Clone the repository or do
       - MQTT_BROKER_URL=mqtt://broker:1883
 ```
 
+When running the services via Docker you must also mount the `/tmp` directory so prebuild commands can access cloned repositories:
+
+```yaml
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp:/tmp
+```
+
 Start the services with:
 
 ```bash


### PR DESCRIPTION
## Summary
- mount `/tmp` on instantiate service for production and dev compose files
- document `/tmp` mount requirement in Docker installation guide

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854729306008323a76a8bf95e20d8e2