### PR TITLE
Add prebuild & service from git docs

### DIFF
--- a/documentation/docs/configuration/prebuild-commands.md
+++ b/documentation/docs/configuration/prebuild-commands.md
@@ -1,0 +1,28 @@
+---
+sidebar_position: 8
+---
+
+# Prebuild Commands
+
+Prebuild commands let you prepare the source code of a service before its image is built. They execute inside a temporary container using the image you specify.
+
+Add a `prebuild` block under a service in `.instantiate/config.yml`:
+
+```yaml
+services:
+  api:
+    prebuild:
+      image: node:23
+      commands:
+        - npm ci
+        - npm run build
+    ports: 1
+```
+
+**Properties**
+
+- `image` – Docker image used to run the commands.
+- `commands` – list of shell commands executed sequentially with `sh -c`.
+- `mountpath` – optional path where the repository is mounted inside the container. Defaults to `/app`.
+
+If the service defines a `repository` section, Instantiate clones that repository and mounts it when running the commands. Otherwise the main project directory is mounted. When using Docker you must also mount `/tmp` on the host so these cloned repositories are accessible.

--- a/documentation/docs/configuration/service-from-git.md
+++ b/documentation/docs/configuration/service-from-git.md
@@ -1,0 +1,27 @@
+---
+sidebar_position: 9
+---
+
+# Service from git
+
+Services can be built from separate repositories. Use the `repository` block to tell Instantiate where to clone the source code.
+
+```yaml
+services:
+  backend:
+    repository:
+      repo: git@github.com:org/backend.git
+      branch: develop
+      behavior: match
+    ports: 1
+```
+
+**Properties**
+
+- `repo` – Git URL of the repository.
+- `branch` – branch to clone. If omitted the repository's default branch is used.
+- `behavior` – how Instantiate selects the branch:
+  - `fixed` (default) always uses the branch defined in `branch` or the default branch.
+  - `match` checks if a branch with the same name as the merge request exists. If found that branch is cloned, otherwise it falls back to `branch` or the default branch.
+
+Credentials for cloning can be provided through the environment variables `REPOSITORY_GITLAB_USERNAME`/`REPOSITORY_GITLAB_TOKEN` or `REPOSITORY_GITHUB_USERNAME`/`REPOSITORY_GITHUB_TOKEN`.

--- a/documentation/sidebars.ts
+++ b/documentation/sidebars.ts
@@ -38,7 +38,9 @@ const sidebars: SidebarsConfig = {
           ],
         },
         'configuration/environment-variables',
-        'configuration/template-variables'
+        'configuration/template-variables',
+        'configuration/prebuild-commands',
+        'configuration/service-from-git'
       ],
     },
     {


### PR DESCRIPTION
## Summary
- document how to use prebuild commands
- document how to instantiate a service from a git repository
- update sidebar navigation

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855e520eac48323bc316d911df704ac