### PR TITLE
Update MR comment on deployment errors

### DIFF
--- a/src/comments/CommentService.ts
+++ b/src/comments/CommentService.ts
@@ -28,5 +28,7 @@ export function generateComment(status: DeploymentStatus, links?: Record<string,
       )
     case 'closed':
       return `${COMMENT_SIGNATURE}\n Stack destroyed due to merge request closure.`
+    case 'error':
+      return `${COMMENT_SIGNATURE}\n Deployment failed.`
   }
 }

--- a/src/comments/MergeRequestCommenter.ts
+++ b/src/comments/MergeRequestCommenter.ts
@@ -1,6 +1,6 @@
 import { MergeRequestPayload } from '../types/MergeRequestPayload'
 
-export type DeploymentStatus = 'in_progress' | 'ready' | 'closed'
+export type DeploymentStatus = 'in_progress' | 'ready' | 'closed' | 'error'
 
 export interface MergeRequestCommenter {
   postStatusComment(payload: MergeRequestPayload, status: DeploymentStatus, links?: Record<string, string>): Promise<void>

--- a/src/core/StackManager.ts
+++ b/src/core/StackManager.ts
@@ -99,6 +99,8 @@ export class StackManager {
       return hostDns
     } catch (err) {
       logger.error(`[stack] Error during the deployment of the stack for MR #${mrId} on project ${projectId}`)
+      await commenter.postStatusComment(payload, 'error')
+      await StackService.updateStatus(projectId, mrId, 'error')
       throw err
     }
   }

--- a/tests/comments/CommentService.test.ts
+++ b/tests/comments/CommentService.test.ts
@@ -27,6 +27,11 @@ describe('generateComment', () => {
     const result = generateComment('closed')
     expect(result).toBe(`${COMMENT_SIGNATURE}\n Stack destroyed due to merge request closure.`)
   })
+
+  it("génère un commentaire pour le statut 'error'", () => {
+    const result = generateComment('error')
+    expect(result).toBe(`${COMMENT_SIGNATURE}\n Deployment failed.`)
+  })
 })
 
 describe('CommentService', () => {


### PR DESCRIPTION
## Summary
- add `error` status in comment utilities
- log deployment error and set MR comment accordingly
- test new `error` status comment

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e48582e34832390649b3d457423fc