### PR TITLE
Allow custom working directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ HOST_SCHEME=http
 # Minimum and maximum ports for stack exposure
 PORT_MIN=10000
 PORT_MAX=11000
+# Base directory for repository checkouts
+WORKING_PATH=/tmp
 
 #------------------------------------------------------------------#
 # Repository configuration

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,7 +13,7 @@ services:
       - "3000:3000"
     volumes:
       - //var/run/docker.sock:/var/run/docker.sock
-      - /tmp:/tmp
+      - ${WORKING_PATH:-/tmp}:${WORKING_PATH:-/tmp}
     environment:
       - NODE_ENV=development
       # - LOG_LEVEL=info      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "3000:3000"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - /tmp:/tmp
+      - ${WORKING_PATH:-/tmp}:${WORKING_PATH:-/tmp}
     environment:
       - NODE_ENV=production
       # - LOG_LEVEL=info

--- a/documentation/docs/configuration/environment-variables.md
+++ b/documentation/docs/configuration/environment-variables.md
@@ -22,3 +22,4 @@ can be defined in a `.env` file or directly in your deployment files. The
 - `IGNORE_SSL_ERRORS` - set to `true` to disable SSL verification when cloning repositories or contacting GitLab.
 - `NODE_ENV` - set to `development` for local testing. It alters clone URLs so containers can reach the host machine.
 - `PORT` - HTTP port for the web server. Defaults to `3000`.
+- `WORKING_PATH` - base directory where repositories are cloned. Defaults to `/tmp`.

--- a/documentation/docs/configuration/prebuild-commands.md
+++ b/documentation/docs/configuration/prebuild-commands.md
@@ -25,4 +25,4 @@ services:
 - `commands` – list of shell commands executed sequentially with `sh -c`.
 - `mountpath` – optional path where the repository is mounted inside the container. Defaults to `/app`.
 
-If the service defines a `repository` section, Instantiate clones that repository and mounts it when running the commands. Otherwise the main project directory is mounted. When using Docker you must also mount `/tmp` on the host so these cloned repositories are accessible.
+If the service defines a `repository` section, Instantiate clones that repository and mounts it when running the commands. Otherwise the main project directory is mounted. When using Docker you must also mount the directory defined by `WORKING_PATH` (default `/tmp`) on the host so these cloned repositories are accessible.

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -32,12 +32,12 @@ Instantiate is distributed as a Docker Compose stack. Clone the repository or do
       - MQTT_BROKER_URL=mqtt://broker:1883
 ```
 
-When running the services via Docker you must also mount the `/tmp` directory so prebuild commands can access cloned repositories:
+When running the services via Docker you must also mount the directory specified by `WORKING_PATH` (default `/tmp`) so prebuild commands can access cloned repositories:
 
 ```yaml
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - /tmp:/tmp
+      - ${WORKING_PATH:-/tmp}:${WORKING_PATH:-/tmp}
 ```
 
 Start the services with:

--- a/src/core/StackManager.ts
+++ b/src/core/StackManager.ts
@@ -1,6 +1,5 @@
 import path from 'path'
 import fs from 'fs/promises'
-import os from 'os'
 import simpleGit, { SimpleGit } from 'simple-git'
 import YAML from 'yaml'
 import { MergeRequestPayload } from '../types/MergeRequestPayload'
@@ -16,6 +15,7 @@ import { StackService } from './StackService'
 import { createDirectory, removeDirectory } from '../utils/ioUtils'
 import { injectCredentialsIfMissing } from '../utils/gitUrl'
 import execa from '../docker/execaWrapper'
+import { getWorkingPath } from '../utils/workingPath'
 
 /**
  * Coordinates the creation and removal of ephemeral stacks for merge requests.
@@ -46,7 +46,7 @@ export class StackManager {
   async deploy(payload: MergeRequestPayload, projectKey: string) {
     const projectId = payload.project_id
     const mrId = payload.mr_id
-    const tmpPath = path.join(os.tmpdir(), 'instantiate', projectId.toString(), mrId.toString())
+    const tmpPath = path.join(getWorkingPath(), 'instantiate', projectId.toString(), mrId.toString())
     let cloneUrl = `${payload.repo}`
     if (payload.provider === 'gitlab') {
       cloneUrl = injectCredentialsIfMissing(cloneUrl, process.env.REPOSITORY_GITLAB_USERNAME, process.env.REPOSITORY_GITLAB_TOKEN)
@@ -121,7 +121,7 @@ export class StackManager {
   async destroy(payload: MergeRequestPayload, projectKey: string) {
     const projectId = payload.project_id
     const mrId = payload.mr_id
-    const tmpPath = path.join(os.tmpdir(), 'instantiate', projectId.toString(), mrId.toString())
+    const tmpPath = path.join(getWorkingPath(), 'instantiate', projectId.toString(), mrId.toString())
     const commenter = CommentService.getCommenter(payload.provider)
 
     try {

--- a/src/health/HealthChecker.ts
+++ b/src/health/HealthChecker.ts
@@ -5,6 +5,7 @@ import { StackInfo, StackService, StackStatus } from '../core/StackService'
 import logger from '../utils/logger'
 import { getOrchestratorAdapter } from '../orchestrators'
 import { buildStackName } from '../utils/nameUtils'
+import { getWorkingPath } from '../utils/workingPath'
 
 export class HealthChecker {
   static async checkStack(stack: StackInfo): Promise<StackStatus> {
@@ -13,7 +14,7 @@ export class HealthChecker {
       let orchestrator = 'compose'
       try {
         const raw = await fs.readFile(
-          path.join(path.join(require('os').tmpdir(), 'instantiate', stack.projectId, stack.mr_id), '.instantiate', 'config.yml'),
+          path.join(path.join(getWorkingPath(), 'instantiate', stack.projectId, stack.mr_id), '.instantiate', 'config.yml'),
           'utf-8'
         )
         const config = YAML.parse(raw)

--- a/src/utils/workingPath.ts
+++ b/src/utils/workingPath.ts
@@ -1,0 +1,3 @@
+export function getWorkingPath(): string {
+  return process.env.WORKING_PATH ?? '/tmp'
+}

--- a/tests/core/StackManager.test.ts
+++ b/tests/core/StackManager.test.ts
@@ -799,6 +799,41 @@ describe('StackManager environment variables', () => {
 
     expect(hostDns).toContain('https://custom-domain')
   })
+
+  it('uses WORKING_PATH for temporary directory', async () => {
+    process.env.WORKING_PATH = '/fic/instantiate'
+    delete process.env.REPOSITORY_GITHUB_TOKEN
+
+    const stackManager = new StackManager()
+    const projectKeyLocal = 'test-project'
+    const localPayload: MergeRequestPayload = {
+      project_id: 'valcriss',
+      projectName: '',
+      mergeRequestName: '',
+      mr_id: 'mr-42',
+      mr_iid: 'mr-42',
+      status: 'open',
+      branch: 'feature/test',
+      repo: 'valcriss/test-repo',
+      sha: 'abcdef123456',
+      author: 'valcriss',
+      full_name: 'valcriss/test-repo',
+      provider: 'github'
+    }
+    const fakeGit = createFakeGit()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockGit.mockReturnValue(fakeGit as any)
+    mockFs.stat.mockResolvedValue({} as Stats)
+    mockFs.readFile.mockResolvedValue('yaml')
+    mockYaml.parse.mockReturnValue({})
+    mockTemplateEngine.renderToFile.mockResolvedValue()
+    mockDocker.prototype.up.mockResolvedValue()
+    mockDb.getUsedPorts.mockResolvedValue(new Set())
+
+    await stackManager.deploy(localPayload, projectKeyLocal)
+
+    expect(fakeGit.clone).toHaveBeenCalledWith(localPayload.repo, expect.stringContaining('/fic/instantiate'), ['--branch', localPayload.branch])
+  })
 })
 
 describe('StackManager additional branches', () => {

--- a/tests/utils/workingPath.test.ts
+++ b/tests/utils/workingPath.test.ts
@@ -1,0 +1,16 @@
+import { getWorkingPath } from '../../src/utils/workingPath'
+
+describe('getWorkingPath', () => {
+  afterEach(() => {
+    delete process.env.WORKING_PATH
+  })
+
+  it('returns the environment value when set', () => {
+    process.env.WORKING_PATH = '/custom'
+    expect(getWorkingPath()).toBe('/custom')
+  })
+
+  it('returns the default when not set', () => {
+    expect(getWorkingPath()).toBe('/tmp')
+  })
+})


### PR DESCRIPTION
## Summary
- support WORKING_PATH environment variable
- update compose files to mount configurable working path
- document the new variable
- test working path utility and add coverage

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e52009bd4832380f470b2b73548a5