### PR TITLE
Add EXCLUDED_PORTS variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ HOST_SCHEME=http
 # Minimum and maximum ports for stack exposure
 PORT_MIN=10000
 PORT_MAX=11000
+# Comma-separated list of ports that should never be used
+EXCLUDED_PORTS=
 # Base directory for repository checkouts
 WORKING_PATH=/tmp
 

--- a/documentation/docs/configuration/environment-variables.md
+++ b/documentation/docs/configuration/environment-variables.md
@@ -14,6 +14,7 @@ can be defined in a `.env` file or directly in your deployment files. The
 - `HOST_SCHEME` - scheme for service URLs (`http` or `https`). Defaults to `http`.
 - `PORT_MIN` - lowest port number available for exposed services. Defaults to `10000`.
 - `PORT_MAX` - highest port number available for exposed services. Defaults to `11000`.
+- `EXCLUDED_PORTS` - comma-separated list of ports that will never be allocated even if free.
 - `REPOSITORY_GITLAB_USERNAME` and `REPOSITORY_GITLAB_TOKEN` - credentials for GitLab access and comments.
 - `REPOSITORY_GITHUB_USERNAME` and `REPOSITORY_GITHUB_TOKEN` - credentials for GitHub access and comments.
 - `DATABASE_URL` - PostgreSQL connection string used by the application.

--- a/src/core/PortAllocator.ts
+++ b/src/core/PortAllocator.ts
@@ -12,6 +12,19 @@ export class PortAllocator {
   private static get portMax(): number {
     return parseInt(process.env.PORT_MAX ?? DEFAULT_PORT_MAX.toString(), 10)
   }
+
+  private static get excludedPorts(): Set<number> {
+    const raw = process.env.EXCLUDED_PORTS
+    if (!raw) return new Set()
+    return new Set(
+      raw
+        .split(',')
+        .map((p) => p.trim())
+        .filter((p) => p.length > 0)
+        .map((p) => parseInt(p, 10))
+        .filter((p) => !Number.isNaN(p))
+    )
+  }
   static async allocatePort(projectId: string, mrId: string, service: string, name: string): Promise<number> {
     const alreadyAllocatedPort = await db.allreadyAllocatedPort(projectId, mrId, service, name)
     if (alreadyAllocatedPort) {
@@ -19,10 +32,11 @@ export class PortAllocator {
       return alreadyAllocatedPort
     }
     const usedPorts = await db.getUsedPorts()
+    const excludedPorts = PortAllocator.excludedPorts
     const min = PortAllocator.portMin
     const max = PortAllocator.portMax
     for (let port = min; port <= max; port++) {
-      if (!usedPorts.has(port)) {
+      if (!usedPorts.has(port) && !excludedPorts.has(port)) {
         await db.addExposedPorts(projectId, mrId, service, name, 0, port)
         logger.info(`[port] Port allocated : ${port} for ${service} ${name} (MR:${mrId})`)
         return port

--- a/tests/core/PortAllocator.test.ts
+++ b/tests/core/PortAllocator.test.ts
@@ -10,11 +10,13 @@ describe('PortAllocator', () => {
 
   const originalPortMin = process.env.PORT_MIN
   const originalPortMax = process.env.PORT_MAX
+  const originalExcluded = process.env.EXCLUDED_PORTS
 
   beforeEach(() => {
     jest.clearAllMocks()
     delete process.env.PORT_MIN
     delete process.env.PORT_MAX
+    delete process.env.EXCLUDED_PORTS
   })
 
   afterEach(() => {
@@ -22,6 +24,8 @@ describe('PortAllocator', () => {
     else delete process.env.PORT_MIN
     if (originalPortMax !== undefined) process.env.PORT_MAX = originalPortMax
     else delete process.env.PORT_MAX
+    if (originalExcluded !== undefined) process.env.EXCLUDED_PORTS = originalExcluded
+    else delete process.env.EXCLUDED_PORTS
   })
 
   afterAll(async () => {
@@ -91,5 +95,16 @@ describe('PortAllocator', () => {
 
     expect(port).toBe(20002)
     expect(mockDb.addExposedPorts).toHaveBeenCalledWith('valcriss', 'mr-env', 'svc', 'SVC_PORT', 0, 20002)
+  })
+
+  it('exclut les ports listés dans EXCLUDED_PORTS', async () => {
+    process.env.EXCLUDED_PORTS = '10002,10003'
+    mockDb.allreadyAllocatedPort.mockResolvedValueOnce(null)
+    mockDb.getUsedPorts.mockResolvedValueOnce(new Set([10000, 10001]))
+
+    const port = await PortAllocator.allocatePort('valcriss', 'mr-ex', 'svc', 'SVC_PORT')
+
+    expect(port).toBe(10004)
+    expect(mockDb.addExposedPorts).toHaveBeenCalledWith('valcriss', 'mr-ex', 'svc', 'SVC_PORT', 0, 10004)
   })
 })


### PR DESCRIPTION
## Summary
- allow port allocator to ignore ports in `EXCLUDED_PORTS`
- document the new variable and example usage
- update tests for excluded ports logic

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e61ca3a388323a11177fc1f85880f