### PR TITLE
Add MQTT worker error logging

### DIFF
--- a/src/mqtt/MQTTWorker.ts
+++ b/src/mqtt/MQTTWorker.ts
@@ -12,6 +12,10 @@ let client: MqttClient
 export function initializeMQTTWorker(brokerUrl: string = process.env.MQTT_BROKER_URL ?? 'mqtt://localhost:1883') {
   client = mqtt.connect(brokerUrl)
 
+  client.on('error', (err) => {
+    logger.error('[mqtt-worker] Error:', err)
+  })
+
   client.on('connect', () => {
     logger.info('[mqtt-worker] MQTT worker started')
     client.subscribe('instantiate/update')

--- a/tests/mqtt/MQTTWorker.test.ts
+++ b/tests/mqtt/MQTTWorker.test.ts
@@ -78,6 +78,13 @@ describe('MQTTWorker', () => {
     expect(mockClient.subscribe).toHaveBeenCalledWith('instantiate/update')
   })
 
+  it('logs errors when an error occurs', () => {
+    const errorCallback = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'error')[1]
+    const err = new Error('mqtt error')
+    errorCallback(err)
+    expect(logger.error).toHaveBeenCalledWith('[mqtt-worker] Error:', err)
+  })
+
   it('initializes when ensureMQTTWorkerIsInitialized is called', () => {
     jest.resetModules()
     const mqttMock = require('mqtt') as { connect: jest.Mock }


### PR DESCRIPTION
## Summary
- log errors from `MQTTWorker` client
- test the new MQTT error logging

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68601b43ec7c8323a500bff232222d76