### PR TITLE
Implement workspace recreation on stack destroy

### DIFF
--- a/tests/core/StackManagerDestroyConfig.test.ts
+++ b/tests/core/StackManagerDestroyConfig.test.ts
@@ -9,7 +9,7 @@ import { closeConnection } from '../../src/mqtt/MQTTClient'
 import { StackService } from '../../src/core/StackService'
 import * as orchestrators from '../../src/orchestrators'
 import { OrchestratorAdapter } from '../../src/orchestrators/OrchestratorAdapter'
-import simpleGit from 'simple-git'
+import simpleGit, { SimpleGit } from 'simple-git'
 
 jest.mock('fs/promises')
 jest.mock('yaml')
@@ -27,10 +27,10 @@ const mockStackService = StackService as jest.Mocked<typeof StackService>
 const mockGetAdapter = orchestrators.getOrchestratorAdapter as jest.MockedFunction<typeof orchestrators.getOrchestratorAdapter>
 const mockGit = simpleGit as jest.MockedFunction<typeof simpleGit>
 
-function createFakeGit() {
+function createFakeGit(): SimpleGit {
   return {
     clone: jest.fn().mockResolvedValue(undefined)
-  }
+  } as unknown as SimpleGit
 }
 
 describe('StackManager.destroy config handling', () => {
@@ -53,7 +53,7 @@ describe('StackManager.destroy config handling', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockGit.mockReturnValue(createFakeGit() as any)
+    mockGit.mockReturnValue(createFakeGit())
     mockFs.stat.mockRejectedValue(new Error('missing'))
   })
 

--- a/tests/core/StackManagerDestroyConfig.test.ts
+++ b/tests/core/StackManagerDestroyConfig.test.ts
@@ -9,6 +9,7 @@ import { closeConnection } from '../../src/mqtt/MQTTClient'
 import { StackService } from '../../src/core/StackService'
 import * as orchestrators from '../../src/orchestrators'
 import { OrchestratorAdapter } from '../../src/orchestrators/OrchestratorAdapter'
+import simpleGit from 'simple-git'
 
 jest.mock('fs/promises')
 jest.mock('yaml')
@@ -16,6 +17,7 @@ jest.mock('../../src/db')
 jest.mock('../../src/core/PortAllocator')
 jest.mock('../../src/core/StackService')
 jest.mock('../../src/orchestrators')
+jest.mock('simple-git')
 
 const mockFs = fs as jest.Mocked<typeof fs>
 const mockYaml = YAML as unknown as { parse: jest.Mock }
@@ -23,6 +25,13 @@ const mockDb = db as jest.Mocked<typeof db>
 const mockPorts = PortAllocator as jest.Mocked<typeof PortAllocator>
 const mockStackService = StackService as jest.Mocked<typeof StackService>
 const mockGetAdapter = orchestrators.getOrchestratorAdapter as jest.MockedFunction<typeof orchestrators.getOrchestratorAdapter>
+const mockGit = simpleGit as jest.MockedFunction<typeof simpleGit>
+
+function createFakeGit() {
+  return {
+    clone: jest.fn().mockResolvedValue(undefined)
+  }
+}
 
 describe('StackManager.destroy config handling', () => {
   const stackManager = new StackManager()
@@ -44,6 +53,8 @@ describe('StackManager.destroy config handling', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockGit.mockReturnValue(createFakeGit() as any)
+    mockFs.stat.mockRejectedValue(new Error('missing'))
   })
 
   afterAll(async () => {
@@ -54,6 +65,8 @@ describe('StackManager.destroy config handling', () => {
   it('uses orchestrator from config file', async () => {
     delete process.env.REPOSITORY_GITHUB_TOKEN
     mockFs.readFile.mockResolvedValueOnce('yaml')
+    mockFs.readFile.mockResolvedValueOnce('compose')
+    mockFs.stat.mockResolvedValue({ isDirectory: () => true } as never)
     mockYaml.parse.mockReturnValueOnce({ orchestrator: 'kubernetes' })
     const adapter: OrchestratorAdapter = {
       up: async () => Promise.resolve(),
@@ -75,6 +88,8 @@ describe('StackManager.destroy config handling', () => {
   it('defaults to compose when orchestrator is missing', async () => {
     delete process.env.REPOSITORY_GITHUB_TOKEN
     mockFs.readFile.mockResolvedValueOnce('yaml')
+    mockFs.readFile.mockResolvedValueOnce('compose')
+    mockFs.stat.mockResolvedValue({ isDirectory: () => true } as never)
     mockYaml.parse.mockReturnValueOnce({})
     const adapter: OrchestratorAdapter = {
       up: async () => Promise.resolve(),
@@ -82,6 +97,27 @@ describe('StackManager.destroy config handling', () => {
       checkHealth: async () => 'running'
     }
     mockGetAdapter.mockReturnValueOnce(adapter)
+
+    await stackManager.destroy(payload, projectKey)
+
+    expect(mockGetAdapter).toHaveBeenCalledWith('compose')
+    expect(adapter.down).toHaveBeenCalled()
+  })
+
+  it('ignore config read errors', async () => {
+    delete process.env.REPOSITORY_GITHUB_TOKEN
+    mockFs.readFile.mockRejectedValueOnce(new Error('fail'))
+    mockFs.stat.mockResolvedValue({ isDirectory: () => true } as never)
+    const adapter: OrchestratorAdapter = {
+      up: async () => Promise.resolve(),
+      down: jest.fn(),
+      checkHealth: async () => 'running'
+    }
+    mockGetAdapter.mockReturnValueOnce(adapter)
+    mockDb.updateMergeRequest.mockResolvedValue()
+    mockStackService.remove.mockResolvedValue()
+    mockPorts.releasePorts.mockResolvedValue()
+    mockFs.rm.mockResolvedValue(undefined)
 
     await stackManager.destroy(payload, projectKey)
 


### PR DESCRIPTION
## Summary
- re-clone repositories and regenerate compose file when destroying a stack
- always clean working directory in `destroy`
- add helper to render compose file
- test GitLab credentials, SSL ignore option and failure scenarios

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68664461c25c83239c2aca3e998c1938