### PR TITLE
Prune Docker images after Swarm stack teardown

### DIFF
--- a/src/orchestrators/DockerSwarmAdapter.ts
+++ b/src/orchestrators/DockerSwarmAdapter.ts
@@ -11,6 +11,7 @@ export class DockerSwarmAdapter implements OrchestratorAdapter {
   async down(_stackPath: string, projectName: string): Promise<void> {
     logger.info(`[swarm] Stack down: ${projectName}`)
     await execa('docker', ['stack', 'rm', projectName])
+    await execa('docker', ['image', 'prune', '-f'])
   }
 
   async checkHealth(projectName: string): Promise<'running' | 'error'> {

--- a/tests/orchestrators/DockerSwarmAdapter.test.ts
+++ b/tests/orchestrators/DockerSwarmAdapter.test.ts
@@ -21,12 +21,13 @@ describe('DockerSwarmAdapter', () => {
     expect(mockedExeca).toHaveBeenCalledWith('docker', ['stack', 'deploy', '-c', 'docker-compose.yml', projectName], expect.objectContaining({ cwd: path }))
   })
 
-  it('removes with docker stack rm', async () => {
+  it('removes stack and prunes images', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mockedExeca.mockResolvedValueOnce({} as any)
+    mockedExeca.mockResolvedValue({} as any)
     const adapter = new DockerSwarmAdapter()
     await adapter.down(path, projectName)
-    expect(mockedExeca).toHaveBeenCalledWith('docker', ['stack', 'rm', projectName])
+    expect(mockedExeca).toHaveBeenNthCalledWith(1, 'docker', ['stack', 'rm', projectName])
+    expect(mockedExeca).toHaveBeenNthCalledWith(2, 'docker', ['image', 'prune', '-f'])
   })
 
   it('checkHealth returns running when replicas match', async () => {


### PR DESCRIPTION
## Summary
- prune Docker images when Docker Swarm stacks are removed
- test DockerSwarmAdapter.down to ensure image prune command is issued

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac227fff4883238e758c039a0caa42