### PR TITLE
Add ignored deployment status to comment service

### DIFF
--- a/src/comments/CommentService.ts
+++ b/src/comments/CommentService.ts
@@ -30,5 +30,7 @@ export function generateComment(status: DeploymentStatus, links?: Record<string,
       return `${COMMENT_SIGNATURE}\n Stack destroyed due to merge request closure.`
     case 'error':
       return `${COMMENT_SIGNATURE}\n Deployment failed.`
+    case 'ignored':
+      return `${COMMENT_SIGNATURE}\n branch ignored by instantiate configuration`
   }
 }

--- a/src/comments/MergeRequestCommenter.ts
+++ b/src/comments/MergeRequestCommenter.ts
@@ -1,6 +1,6 @@
 import { MergeRequestPayload } from '../types/MergeRequestPayload'
 
-export type DeploymentStatus = 'in_progress' | 'ready' | 'closed' | 'error'
+export type DeploymentStatus = 'in_progress' | 'ready' | 'closed' | 'error' | 'ignored'
 
 export interface MergeRequestCommenter {
   postStatusComment(payload: MergeRequestPayload, status: DeploymentStatus, links?: Record<string, string>): Promise<void>

--- a/tests/comments/CommentService.test.ts
+++ b/tests/comments/CommentService.test.ts
@@ -32,6 +32,11 @@ describe('generateComment', () => {
     const result = generateComment('error')
     expect(result).toBe(`${COMMENT_SIGNATURE}\n Deployment failed.`)
   })
+
+  it("génère un commentaire pour le statut 'ignored'", () => {
+    const result = generateComment('ignored')
+    expect(result).toBe(`${COMMENT_SIGNATURE}\n branch ignored by instantiate configuration`)
+  })
 })
 
 describe('CommentService', () => {


### PR DESCRIPTION
## Summary
- support new `ignored` deployment status in merge request commenter
- generate informative comment when branch is ignored
- test comment generation for ignored status

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad7c61654c8323b60eed74d4707f76