### PR TITLE
Handle blank WORKING_PATH env

### DIFF
--- a/src/utils/workingPath.ts
+++ b/src/utils/workingPath.ts
@@ -1,3 +1,7 @@
 export function getWorkingPath(): string {
-  return process.env.WORKING_PATH ?? '/tmp'
+  const envPath = process.env.WORKING_PATH
+  if (envPath && envPath.trim() !== '') {
+    return envPath
+  }
+  return '/tmp'
 }

--- a/tests/utils/workingPath.test.ts
+++ b/tests/utils/workingPath.test.ts
@@ -10,6 +10,11 @@ describe('getWorkingPath', () => {
     expect(getWorkingPath()).toBe('/custom')
   })
 
+  it('returns the default when set to only whitespace', () => {
+    process.env.WORKING_PATH = '   '
+    expect(getWorkingPath()).toBe('/tmp')
+  })
+
   it('returns the default when not set', () => {
     expect(getWorkingPath()).toBe('/tmp')
   })


### PR DESCRIPTION
## Summary
- treat whitespace WORKING_PATH env var as unset and fall back to default
- test whitespace handling in getWorkingPath

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad8304dc7083238e33984ea715c2be