### PR TITLE
refactor: disable logger transport in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "postbuild": "npx ncp src/templates dist/templates",
     "start": "node dist/server.js",
     "migrate:up": "node-pg-migrate up",
-    "test": "jest --coverage --forceExit",
+    "test": "jest --coverage",
     "test:watch": "jest --watch",
     "lint": "eslint --ext .ts src migrations tests",
     "format": "eslint --ext .ts src migrations tests --fix",

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,22 +1,36 @@
-import pino from 'pino'
+import pino, { type Logger } from 'pino'
 
-const logger = pino({
+const isTest = process.env.NODE_ENV === 'test'
+
+type ExtendedLogger = Logger & {
+  transport?: { end?: () => void }
+  removeAllListeners?: () => void
+}
+
+const logger: ExtendedLogger = pino({
   level: process.env.LOG_LEVEL ?? 'info',
-  transport: {
-    target: 'pino-pretty',
-    options: {
-      colorize: true,
-      translateTime: 'HH:MM:ss Z',
-      ignore: 'pid,hostname'
-    }
-  }
-})
+  ...(isTest
+    ? {}
+    : {
+        transport: {
+          target: 'pino-pretty',
+          options: {
+            colorize: true,
+            translateTime: 'HH:MM:ss Z',
+            ignore: 'pid,hostname'
+          }
+        }
+      })
+}) as ExtendedLogger
 
 export const closeLogger = () => {
   if (logger.flush) {
     logger.flush()
-    logger.removeAllListeners()
   }
+  if (!isTest && logger.transport?.end) {
+    logger.transport.end()
+  }
+  logger.removeAllListeners?.()
 }
 
 export default logger


### PR DESCRIPTION
## Summary
- avoid pino transport in tests to prevent open handles
- adjust logger cleanup and tests
- run tests without `--forceExit`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae11e164a08323b8894ec6d6596845