### PR TITLE
Fix logger parameter order to satisfy TypeScript and tests

### DIFF
--- a/src/api/update.ts
+++ b/src/api/update.ts
@@ -9,10 +9,13 @@ import { CommentService } from '../comments/CommentService'
 const router = express.Router()
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 router.post('/update', async (req: any, res: any) => {
-  logger.debug('[api] Incoming webhook', {
-    query: req.query,
-    headers: req.headers
-  })
+  logger.debug(
+    {
+      query: req.query,
+      headers: req.headers
+    },
+    '[api] Incoming webhook'
+  )
 
   const projectKey = req.query.key as string
   const headers = req.headers
@@ -30,7 +33,7 @@ router.post('/update', async (req: any, res: any) => {
     provider = 'github'
   }
 
-  logger.debug('[api] Determined provider', provider)
+  logger.debug({ provider }, '[api] Determined provider')
 
   if (!provider) {
     logger.warn('[api] Unsupported source control provider')

--- a/src/health/HealthChecker.ts
+++ b/src/health/HealthChecker.ts
@@ -26,7 +26,7 @@ export class HealthChecker {
       const status = await adapter.checkHealth(projectName)
       return status
     } catch (err) {
-      logger.error('[health] Error checking stack', err)
+      logger.error({ err }, '[health] Error checking stack')
       return 'error'
     }
   }
@@ -45,7 +45,7 @@ export class HealthChecker {
 export function startHealthChecker(intervalMs = 30000) {
   setInterval(() => {
     HealthChecker.checkAllStacks().catch((err) => {
-      logger.error('[health] Error during health check loop', err)
+      logger.error({ err }, '[health] Error during health check loop')
     })
   }, intervalMs)
 }

--- a/src/mqtt/MQTTClient.ts
+++ b/src/mqtt/MQTTClient.ts
@@ -18,8 +18,8 @@ export function initializeMQTTClient(brokerUrl: string = process.env.MQTT_BROKER
   })
 
   client.on('error', (err) => {
-    logger.info('[mqtt-client] Error:', err.message)
-    logger.error('[mqtt-client] Error:', err)
+    logger.info({ err: err.message }, '[mqtt-client] Error')
+    logger.error({ err }, '[mqtt-client] Error')
   })
 
   return client
@@ -39,7 +39,7 @@ export async function closeConnection() {
   return new Promise((resolve, reject) => {
     client?.end(false, {}, (err) => {
       if (err) {
-        logger.error('[mqtt-client] Error closing connection:', err)
+        logger.error({ err }, '[mqtt-client] Error closing connection')
         return reject(err)
       }
       client = null

--- a/src/mqtt/MQTTWorker.ts
+++ b/src/mqtt/MQTTWorker.ts
@@ -13,7 +13,7 @@ export function initializeMQTTWorker(brokerUrl: string = process.env.MQTT_BROKER
   client = mqtt.connect(brokerUrl)
 
   client.on('error', (err) => {
-    logger.error('[mqtt-worker] Error:', err)
+    logger.error({ err }, '[mqtt-worker] Error')
   })
 
   client.on('connect', () => {
@@ -32,7 +32,7 @@ export function initializeMQTTWorker(brokerUrl: string = process.env.MQTT_BROKER
         await stackManager.destroy(payload, projectKey)
       }
     } catch (err) {
-      logger.error('[mqtt-worker] Error processing message:', err)
+      logger.error({ err }, '[mqtt-worker] Error processing message')
       logger.error(err)
     }
   })

--- a/src/orchestrators/DockerComposeAdapter.ts
+++ b/src/orchestrators/DockerComposeAdapter.ts
@@ -41,7 +41,7 @@ export class DockerComposeAdapter implements OrchestratorAdapter {
       const states = stdout.split('\n').filter(Boolean)
       return states.every((s) => s === 'running') ? 'running' : 'error'
     } catch (err) {
-      logger.error('[docker] Error checking stack', err)
+      logger.error({ err }, '[docker] Error checking stack')
       return 'error'
     }
   }

--- a/src/orchestrators/DockerSwarmAdapter.ts
+++ b/src/orchestrators/DockerSwarmAdapter.ts
@@ -23,7 +23,7 @@ export class DockerSwarmAdapter implements OrchestratorAdapter {
       const replicas = stdout.split('\n').filter(Boolean)
       return replicas.every((r) => r.split('/')[0] === r.split('/')[1]) ? 'running' : 'error'
     } catch (err) {
-      logger.error('[swarm] Error checking stack', err)
+      logger.error({ err }, '[swarm] Error checking stack')
       return 'error'
     }
   }

--- a/src/orchestrators/KubernetesAdapter.ts
+++ b/src/orchestrators/KubernetesAdapter.ts
@@ -22,7 +22,7 @@ export class KubernetesAdapter implements OrchestratorAdapter {
       const phases = stdout.trim().split(/\s+/)
       return phases.every((p) => p === 'Running') ? 'running' : 'error'
     } catch (err) {
-      logger.error('[k8s] Error checking stack', err)
+      logger.error({ err }, '[k8s] Error checking stack')
       return 'error'
     }
   }

--- a/tests/mqtt/MQTTClient.test.ts
+++ b/tests/mqtt/MQTTClient.test.ts
@@ -88,7 +88,7 @@ describe('MQTTClient', () => {
       mockClient.end = jest.fn((force: boolean, options: any, callback: (err?: Error) => void) => callback(error))
 
       await expect(closeConnection()).rejects.toThrow('Close connection error')
-      expect(logger.error).toHaveBeenCalledWith('[mqtt-client] Error closing connection:', error)
+      expect(logger.error).toHaveBeenCalledWith({ err: error }, '[mqtt-client] Error closing connection')
     })
   })
 
@@ -109,7 +109,7 @@ describe('MQTTClient', () => {
       const error = new Error('Test error')
       errorCallback(error)
 
-      expect(logger.info).toHaveBeenCalledWith('[mqtt-client] Error:', error.message)
+      expect(logger.info).toHaveBeenCalledWith({ err: error.message }, '[mqtt-client] Error')
     })
   })
 })

--- a/tests/mqtt/MQTTWorker.test.ts
+++ b/tests/mqtt/MQTTWorker.test.ts
@@ -60,7 +60,7 @@ describe('MQTTWorker', () => {
     mockDeploy.mockRejectedValueOnce(err)
     const payload = { status: 'open' }
     await messageCallback('instantiate/update', Buffer.from(JSON.stringify({ payload, projectKey: 'key' })))
-    expect(logger.error).toHaveBeenCalledWith('[mqtt-worker] Error processing message:', err)
+    expect(logger.error).toHaveBeenCalledWith({ err }, '[mqtt-worker] Error processing message')
     expect(logger.error).toHaveBeenCalledWith(err)
   })
 
@@ -82,7 +82,7 @@ describe('MQTTWorker', () => {
     const errorCallback = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'error')[1]
     const err = new Error('mqtt error')
     errorCallback(err)
-    expect(logger.error).toHaveBeenCalledWith('[mqtt-worker] Error:', err)
+    expect(logger.error).toHaveBeenCalledWith({ err }, '[mqtt-worker] Error')
   })
 
   it('initializes when ensureMQTTWorkerIsInitialized is called', () => {


### PR DESCRIPTION
## Summary
- log structured data before message to match pino signature
- handle MQTT and orchestrator errors with structured logging
- update tests for new logging format

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8b7ff4960832387748f64bd805ad1