### PR TITLE
Handle ignored merge requests with stored comments

### DIFF
--- a/src/api/update.ts
+++ b/src/api/update.ts
@@ -5,6 +5,7 @@ import { parseGithubWebhook } from '../providers/github'
 import { ensureMQTTClientIsInitialized, publishUpdateEvent } from '../mqtt/MQTTClient'
 import { MergeRequestPayload } from '../types/MergeRequestPayload'
 import { CommentService } from '../comments/CommentService'
+import db from '../db'
 
 const router = express.Router()
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -46,6 +47,7 @@ router.post('/update', async (req: any, res: any) => {
     const ignoredPrefix = process.env.IGNORE_BRANCH_PREFIX
     if (ignoredPrefix && payload.branch.startsWith(ignoredPrefix)) {
       logger.info(`[api] Ignoring branch ${payload.branch} due to prefix ${ignoredPrefix}`)
+      await db.updateMergeRequest(payload, 'ignored')
       if (payload.status === 'open') {
         const commenter = CommentService.getCommenter(payload.provider)
         await commenter.postStatusComment(payload, 'ignored')


### PR DESCRIPTION
## Summary
- store ignored merge requests in the database
- reuse existing comment IDs for ignored branches
- test ignored branch behavior and prevent duplicate comments

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be72eeae088323a30230eb349969bc