### PR TITLE
Verify port availability before reusing stored allocations

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -32,6 +32,18 @@ export default {
       [projectId, mrId, service, name, internalPort, port]
     )
   },
+  updateExposedPort: async (projectId: string, mrId: string, service: string, name: string, port: number) => {
+    await pool.query(`UPDATE exposed_ports SET external_port = $5 WHERE project_id = $1 AND mr_id = $2 AND service = $3 AND name = $4`, [
+      projectId,
+      mrId,
+      service,
+      name,
+      port
+    ])
+  },
+  removeExposedPort: async (projectId: string, mrId: string, service: string, name: string) => {
+    await pool.query(`DELETE FROM exposed_ports WHERE project_id = $1 AND mr_id = $2 AND service = $3 AND name = $4`, [projectId, mrId, service, name])
+  },
   releasePorts: async (projectId: string, mrId: string) => {
     await pool.query(`DELETE FROM exposed_ports WHERE project_id = $1 AND mr_id = $2`, [projectId, mrId])
   },

--- a/src/utils/portUtils.ts
+++ b/src/utils/portUtils.ts
@@ -1,0 +1,100 @@
+import execa from '../docker/execaWrapper'
+import net from 'net'
+import logger from './logger'
+
+const DOCKER_PS_ARGS = ['ps', '--format', '{{.Ports}}']
+
+const parseRange = (range: string): number[] => {
+  const [startRaw, endRaw] = range.split('-')
+  const start = Number.parseInt(startRaw, 10)
+  const end = Number.parseInt(endRaw, 10)
+
+  if (Number.isNaN(start) || Number.isNaN(end)) {
+    return []
+  }
+
+  const [min, max] = start <= end ? [start, end] : [end, start]
+  const ports: number[] = []
+  for (let port = min; port <= max; port++) {
+    ports.push(port)
+  }
+
+  return ports
+}
+
+const collectHostPorts = (segment: string, accumulator: Set<number>) => {
+  if (!segment.includes('->')) return
+  const [hostPart] = segment.split('->')
+  const rawPort = hostPart.split(':').pop()?.trim()
+  if (!rawPort) return
+
+  if (rawPort.includes('-')) {
+    for (const port of parseRange(rawPort)) {
+      accumulator.add(port)
+    }
+    return
+  }
+
+  const port = Number.parseInt(rawPort, 10)
+  if (!Number.isNaN(port)) {
+    accumulator.add(port)
+  }
+}
+
+export const getDockerExposedPorts = async (): Promise<Set<number>> => {
+  try {
+    const { stdout } = await execa('docker', DOCKER_PS_ARGS)
+    if (!stdout) {
+      return new Set()
+    }
+
+    const ports = new Set<number>()
+    const lines = stdout.split('\n').map((line) => line.trim())
+
+    for (const line of lines) {
+      if (!line) continue
+      const segments = line.split(',')
+      for (const segment of segments) {
+        collectHostPorts(segment.trim(), ports)
+      }
+    }
+
+    return ports
+  } catch (error) {
+    logger.debug({ error }, '[port] Unable to read docker host ports, assuming none are exposed')
+    return new Set()
+  }
+}
+
+export const isHostPortFree = (port: number): Promise<boolean> => {
+  return new Promise((resolve) => {
+    const server = net.createServer()
+    server.unref()
+
+    const finish = (result: boolean) => {
+      server.removeAllListeners('error')
+      resolve(result)
+    }
+
+    server.once('error', () => {
+      finish(false)
+    })
+
+    server.listen({ port, host: '0.0.0.0', exclusive: true }, () => {
+      server.close(() => {
+        finish(true)
+      })
+    })
+  })
+}
+
+export const isPortFree = async (port: number, dockerPorts?: Set<number>): Promise<boolean> => {
+  const exposedPorts = dockerPorts ?? (await getDockerExposedPorts())
+  if (exposedPorts.has(port)) {
+    return false
+  }
+
+  return await isHostPortFree(port)
+}
+
+export default isPortFree

--- a/tests/core/PortAllocator.test.ts
+++ b/tests/core/PortAllocator.test.ts
@@ -2,11 +2,20 @@ import { PortAllocator } from '../../src/core/PortAllocator'
 import db from '../../src/db'
 import { closeConnection } from '../../src/mqtt/MQTTClient'
 import { closeLogger } from '../../src/utils/logger'
+import * as portUtils from '../../src/utils/portUtils'
 
 jest.mock('../../src/db')
+jest.mock('../../src/utils/portUtils', () => ({
+  __esModule: true,
+  getDockerExposedPorts: jest.fn(),
+  isPortFree: jest.fn()
+}))
 
 describe('PortAllocator', () => {
   const mockDb = db as jest.Mocked<typeof db>
+  const mockPortUtils = portUtils as jest.Mocked<typeof portUtils>
+
+  let dockerPorts: Set<number>
 
   const originalPortMin = process.env.PORT_MIN
   const originalPortMax = process.env.PORT_MAX
@@ -17,6 +26,9 @@ describe('PortAllocator', () => {
     delete process.env.PORT_MIN
     delete process.env.PORT_MAX
     delete process.env.EXCLUDED_PORTS
+    dockerPorts = new Set<number>()
+    mockPortUtils.getDockerExposedPorts.mockResolvedValue(dockerPorts)
+    mockPortUtils.isPortFree.mockImplementation(async () => true)
   })
 
   afterEach(() => {
@@ -41,6 +53,7 @@ describe('PortAllocator', () => {
 
     expect(port).toEqual(10002)
     expect(mockDb.addExposedPorts).toHaveBeenCalledWith('valcriss', 'mr-1', 'web', 'WEB_PORT', 0, 10002)
+    expect(mockPortUtils.isPortFree).toHaveBeenCalledWith(10002, dockerPorts)
   })
 
   it('ignore les ports déjà utilisés', async () => {
@@ -83,6 +96,7 @@ describe('PortAllocator', () => {
 
     expect(port).toBe(10005)
     expect(mockDb.allreadyAllocatedPort).toHaveBeenCalledWith('valcriss', 'mr-4', 'cache', 'CACHE_PORT')
+    expect(mockPortUtils.isPortFree).toHaveBeenCalledWith(10005, dockerPorts)
   })
 
   it("utilise les variables d'environnement PORT_MIN et PORT_MAX", async () => {
@@ -106,5 +120,32 @@ describe('PortAllocator', () => {
 
     expect(port).toBe(10004)
     expect(mockDb.addExposedPorts).toHaveBeenCalledWith('valcriss', 'mr-ex', 'svc', 'SVC_PORT', 0, 10004)
+  })
+
+  it('réalloue un port si la valeur enregistrée est occupée', async () => {
+    mockDb.allreadyAllocatedPort.mockResolvedValueOnce(10002)
+    mockDb.getUsedPorts.mockResolvedValueOnce(new Set([10002]))
+    mockPortUtils.isPortFree.mockImplementation(async (port) => {
+      if (port === 10002) return false
+      if (port === 10000) return false
+      return true
+    })
+
+    const port = await PortAllocator.allocatePort('valcriss', 'mr-5', 'cache', 'CACHE_PORT')
+
+    expect(port).toBe(10001)
+    expect(mockDb.updateExposedPort).toHaveBeenCalledWith('valcriss', 'mr-5', 'cache', 'CACHE_PORT', 10001)
+    expect(mockDb.addExposedPorts).not.toHaveBeenCalled()
+  })
+
+  it("ignore les ports occupés sur l'hôte lors d'une nouvelle allocation", async () => {
+    mockDb.allreadyAllocatedPort.mockResolvedValueOnce(null)
+    mockDb.getUsedPorts.mockResolvedValueOnce(new Set())
+    mockPortUtils.isPortFree.mockImplementation(async (port) => port !== 10000)
+
+    const port = await PortAllocator.allocatePort('valcriss', 'mr-6', 'svc', 'SVC_PORT')
+
+    expect(port).toBe(10001)
+    expect(mockDb.addExposedPorts).toHaveBeenCalledWith('valcriss', 'mr-6', 'svc', 'SVC_PORT', 0, 10001)
   })
 })

--- a/tests/db/db.test.ts
+++ b/tests/db/db.test.ts
@@ -128,6 +128,32 @@ describe('db/index.ts', () => {
     expect(mockPoolInstance.query).toHaveBeenCalled()
   })
 
+  it('updateExposedPort met à jour le port exposé existant', async () => {
+    const mockPoolInstance = (Pool as unknown as jest.Mock).mock.results[0].value
+    mockPoolInstance.query.mockClear()
+
+    await db.updateExposedPort('123', '456', 'test-service', 'test-name', 4242)
+
+    expect(mockPoolInstance.query).toHaveBeenCalledWith(
+      `UPDATE exposed_ports SET external_port = $5 WHERE project_id = $1 AND mr_id = $2 AND service = $3 AND name = $4`,
+      ['123', '456', 'test-service', 'test-name', 4242]
+    )
+  })
+
+  it('removeExposedPort supprime une entrée de port exposé', async () => {
+    const mockPoolInstance = (Pool as unknown as jest.Mock).mock.results[0].value
+    mockPoolInstance.query.mockClear()
+
+    await db.removeExposedPort('123', '456', 'test-service', 'test-name')
+
+    expect(mockPoolInstance.query).toHaveBeenCalledWith(`DELETE FROM exposed_ports WHERE project_id = $1 AND mr_id = $2 AND service = $3 AND name = $4`, [
+      '123',
+      '456',
+      'test-service',
+      'test-name'
+    ])
+  })
+
   it('releasePorts supprime les ports exposés pour un projet et une MR donnés', async () => {
     const mockPoolInstance = (Pool as unknown as jest.Mock).mock.results[0].value
 

--- a/tests/utils/portUtils.test.ts
+++ b/tests/utils/portUtils.test.ts
@@ -1,0 +1,91 @@
+import net, { AddressInfo } from 'net'
+import execa from '../../src/docker/execaWrapper'
+import * as portUtils from '../../src/utils/portUtils'
+
+jest.mock('../../src/docker/execaWrapper')
+
+const mockExeca = execa as jest.Mock
+
+describe('portUtils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('analyse correctement les ports exposés par Docker', async () => {
+    mockExeca.mockResolvedValue({
+      stdout:
+        '0.0.0.0:80->80/tcp, :::80->80/tcp, 80/tcp, 0.0.0.0:abc-def->90/tcp, 0.0.0.0:abc->70/tcp, ::->100/tcp\n\n0.0.0.0:8080->8080/tcp\n0.0.0.0:3000-3002->3000-3002/tcp'
+    })
+
+    const ports = await portUtils.getDockerExposedPorts()
+
+    expect(Array.from(ports).sort((a, b) => a - b)).toEqual([80, 3000, 3001, 3002, 8080])
+  })
+
+  it('gère les plages inversées dans la sortie Docker', async () => {
+    mockExeca.mockResolvedValue({ stdout: '0.0.0.0:5-3->5-3/tcp' })
+
+    const ports = await portUtils.getDockerExposedPorts()
+
+    expect(Array.from(ports).sort((a, b) => a - b)).toEqual([3, 4, 5])
+  })
+
+  it('retourne un ensemble vide si la commande Docker échoue', async () => {
+    mockExeca.mockRejectedValue(new Error('docker unavailable'))
+
+    const ports = await portUtils.getDockerExposedPorts()
+
+    expect(ports.size).toBe(0)
+  })
+
+  it("détecte qu'un port est occupé via la liste Docker", async () => {
+    const available = await portUtils.isPortFree(80, new Set([80]))
+    expect(available).toBe(false)
+  })
+
+  it("interroge l'hôte quand le port n'est pas dans la liste Docker", async () => {
+    const hostSpy = jest.spyOn(portUtils, 'isHostPortFree').mockResolvedValueOnce(true)
+
+    const free = await portUtils.isPortFree(12345, new Set())
+
+    expect(free).toBe(true)
+    expect(hostSpy).toHaveBeenCalledWith(12345)
+    hostSpy.mockRestore()
+  })
+
+  it("récupère les ports Docker quand aucun ensemble n'est fourni", async () => {
+    mockExeca.mockResolvedValue({ stdout: '' })
+    const hostSpy = jest.spyOn(portUtils, 'isHostPortFree').mockResolvedValueOnce(true)
+
+    const free = await portUtils.isPortFree(23456)
+
+    expect(free).toBe(true)
+    expect(mockExeca).toHaveBeenCalledTimes(1)
+    expect(hostSpy).toHaveBeenCalledWith(23456)
+    hostSpy.mockRestore()
+  })
+
+  it("indique correctement si un port est libre sur l'hôte", async () => {
+    const server = net.createServer()
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen({ port: 0, host: '0.0.0.0' }, resolve)
+    })
+
+    const { port } = server.address() as AddressInfo
+
+    const busy = await portUtils.isHostPortFree(port)
+    expect(busy).toBe(false)
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err)
+        else resolve()
+      })
+    })
+
+    const free = await portUtils.isHostPortFree(port)
+    expect(free).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add a port utility that inspects docker exposure and probes the host before marking a port as free
- update the port allocator to verify stored ports, refresh busy allocations in the database, and skip ports that fail the new checks
- expand database and unit tests to cover port updates and the new availability utility

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d28e3fbdf48323be86f7abd2d117f7